### PR TITLE
advertise regex support availability in lognorm-features.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,7 +71,11 @@ AM_CONDITIONAL(ENABLE_REGEXP, test x$enable_regexp = xyes)
 if test "$enable_regexp" = "yes"; then
         AX_PATH_LIB_PCRE
         AC_DEFINE(FEATURE_REGEXP, 1, [Regular expressions support enabled.])
+	FEATURE_REGEXP=1
+else
+	FEATURE_REGEXP=0
 fi
+AC_SUBST(FEATURE_REGEXP)
 
 # debug mode settings
 AC_ARG_ENABLE(debug,
@@ -130,6 +134,7 @@ AC_CONFIG_FILES([Makefile \
 		lognorm.pc \
 		doc/Makefile \
 		src/Makefile \
+		src/lognorm-features.h \
 		tests/Makefile \
 		tests/options.sh])
 AC_OUTPUT

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -6,3 +6,4 @@ Makefile.in
 .deps
 .libs
 lognormalizer
+lognorm-features.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -47,4 +47,4 @@ EXTRA_DIST = \
 	enc.h \
 	parser.h
 
-include_HEADERS = liblognorm.h samp.h lognorm.h ptree.h annot.h enc.h parser.h
+include_HEADERS = liblognorm.h samp.h lognorm.h ptree.h annot.h enc.h parser.h lognorm-features.h

--- a/src/lognorm-features.h.in
+++ b/src/lognorm-features.h.in
@@ -1,0 +1,3 @@
+#if @FEATURE_REGEXP@
+#define LOGNORM_REGEX_SUPPORTED 1
+#endif


### PR DESCRIPTION
This is required for downstream packages to do conditional things based on regex support being available.

Eg. a tests in rsyslog suite must not be run when lognorm is built without regex support.
