### PR TITLE
Recursive field support + type-interpretation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,5 @@ test-driver
 *.trs
 *.log
 test.out
-tmp.rulebase
 src/ln_test
 tests/options.sh

--- a/configure.ac
+++ b/configure.ac
@@ -54,6 +54,9 @@ CFLAGS="$CFLAGS $JSON_C_CFLAGS"
 LIBS="$LIBS $JSON_C_LIBS"
 AC_CHECK_FUNCS(json_object_object_get_ex,,)
 AC_CHECK_FUNCS(json_object_get_string_len,,)
+AC_CHECK_TYPE(json_bool,,,)
+AC_CHECK_FUNCS(json_object_get_int64,,)
+AC_CHECK_FUNCS(json_object_new_int64,,)
 LIBS="$LIBS_BEFORE"
 CFLAGS="$CFLAGS_BEFORE"
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -274,8 +274,8 @@ content under the key 'foo'.
 However, matching initial fragment of text requires the remaining 
 (suffix-fragment) portion of it to be matched and given back to 
 original field so it can be matched by remaining portion of rule
-which follows the matched rule(remember, it is being called to match 
-only a portion of text from another rule). 
+which follows the matched fragmet(remember, it is being called to 
+match only a portion of text from another rule). 
 
 Additional argument can be passed to pick field-name to be used for 
 returning unmatched text. It is optional, and defaults to 'tail'. The
@@ -285,7 +285,7 @@ example below uses 'remains' as the field name insteed of 'tail'.
 
     %foo:recursive:remains%
 
-Recursive fields are often useful in combination with tokenized text.
+Recursive fields are often useful in combination with tokenized field.
 This ruleset for instance, will match multiple IPv4 addresses or 
 Subnets in expected message.
 
@@ -320,6 +320,43 @@ unmatched portion of text. The example below is rewritten to use field
     rule=:%subnet_addr:ipv4%/%subnet_mask:number%%remains:rest%
     rule=:%ip_addr:ipv4%%remains:rest%
     rule=:blocked inbound via: %via_ip:ipv4% from: %addresses:tokenized:, :recursive:remains% to %server_ip:ipv4%
+
+descent
+#######
+
+Value that matches some other rule defined in a different rulebase. Its called
+descent because it descends down to a child rulebase and invokes the entire 
+parser-tree again. Its like recursive, except it calls a different rulebase for
+recursive parsing(as opposed to recursive which calls itself). It takes two 
+arguments, first is the file name and second is optional argument explained 
+below.
+
+The invocation below will call the ruleset in /foo/bar.rulebase and put the 
+parsed content under the key 'foo'.
+
+::
+
+    %foo:descent:/foo/bar.rulebase%
+
+Like recursive, matching initial fragment of text requires the remaining 
+(suffix-fragment) portion of it to be matched and given back to 
+original field(this is explained in detail in documentation for recursive 
+field).
+
+Additional argument can be passed to pick field-name to be used for 
+returning unmatched text. It is optional, and defaults to 'tail'. The
+example below uses 'remains' as the field name insteed of 'tail'.
+
+::
+
+    %foo:descent:/foo/bar.rulebase:remains%
+
+Like recursive, descent field is often useful in combination with tokenized 
+field. The usage example for this would look very similar to that of recursive 
+(with field declaration changing to include rulebase path).
+
+This brings with it the overhead of having to maintain multiple rulebase files, 
+but also helps alleviate complexity when a single ruleset becomes too complex.
 
 regex
 #####

--- a/src/json_compatibility.c
+++ b/src/json_compatibility.c
@@ -17,3 +17,16 @@ int json_object_get_string_len(struct json_object *obj) {
 	return strlen(str);
 }
 #endif
+
+#ifndef HAVE_JSON_OBJECT_GET_INT64
+int64_t json_object_get_int64(struct json_object *jso) {
+	int64_t val = json_object_get_int(jso);
+	return val;
+}
+#endif
+
+#ifndef HAVE_JSON_OBJECT_NEW_INT64
+struct json_object* json_object_new_int64(int64_t i) {
+	return json_object_new_int((int) i);
+}
+#endif

--- a/src/json_compatibility.h
+++ b/src/json_compatibility.h
@@ -1,4 +1,5 @@
 #include <json.h>
+#include <inttypes.h>
 
 #ifndef HAVE_JSON_OBJECT_OBJECT_GET_EX
 int json_object_object_get_ex(struct json_object* obj,
@@ -8,4 +9,16 @@ int json_object_object_get_ex(struct json_object* obj,
 
 #ifndef HAVE_JSON_OBJECT_GET_STRING_LEN
 int json_object_get_string_len(struct json_object *obj);
+#endif
+
+#ifndef HAVE_JSON_BOOL
+typedef int json_bool;
+#endif
+
+#ifndef HAVE_JSON_OBJECT_GET_INT64
+int64_t json_object_get_int64(struct json_object *jso);
+#endif
+
+#ifndef HAVE_JSON_OBJECT_NEW_INT64
+struct json_object* json_object_new_int64(int64_t i);
 #endif

--- a/src/liblognorm.h
+++ b/src/liblognorm.h
@@ -66,6 +66,7 @@
 /* error codes */
 #define LN_NOMEM -1
 #define LN_INVLDFDESCR -1
+#define LN_BADCONFIG -250
 #define LN_BADPARSERSTATE -500
 #define LN_WRONGPARSER -1000
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -1133,10 +1133,10 @@ void regex_parser_data_destructor(void** dataPtr) {
  */
 typedef enum interpret_type {
 	/* If you change this, be sure to update json_type_to_name() too */
-	b10int,
-	b16int,
-	floating_pt,
-	boolean
+	it_b10int,
+	it_b16int,
+	it_floating_pt,
+	it_boolean
 } interpret_type;
 
 struct interpret_parser_data_s {
@@ -1172,16 +1172,16 @@ static json_object* interpret_as_boolean(json_object *value) {
 
 static int reinterpret_value(json_object **value, enum interpret_type to_type) {
 	switch(to_type) {
-	case b10int:
+	case it_b10int:
 		*value = interpret_as_int(*value, 10);
 		break;
-	case b16int:
+	case it_b16int:
 		*value = interpret_as_int(*value, 16);
 		break;
-	case floating_pt:
+	case it_floating_pt:
 		*value = interpret_as_double(*value);
 		break;
-	case boolean:
+	case it_boolean:
 		*value = interpret_as_boolean(*value);
 		break;
 	default:
@@ -1233,13 +1233,13 @@ void* interpret_parser_data_constructor(ln_fieldList_t *node, ln_ctx ctx) {
 	CHKN(args = pcons_args(node->raw_data, 2));
 	CHKN(type_str = pcons_arg(args, 0, NULL));
 	if (strcmp(type_str, "int") == 0 || strcmp(type_str, "base10int") == 0) {
-		pData->intrprt = b10int;
+		pData->intrprt = it_b10int;
 	} else if (strcmp(type_str, "base16int") == 0) {
-		pData->intrprt = b16int;
+		pData->intrprt = it_b16int;
 	} else if (strcmp(type_str, "float") == 0) {
-		pData->intrprt = floating_pt;
+		pData->intrprt = it_floating_pt;
 	} else if (strcmp(type_str, "bool") == 0) {
-		pData->intrprt = boolean;
+		pData->intrprt = it_boolean;
 	} else {
 		bad_interpret = 1;
 		FAIL(LN_BADCONFIG);

--- a/src/parser.c
+++ b/src/parser.c
@@ -896,6 +896,38 @@ void regex_parser_data_destructor(void** dataPtr) {
 
 #endif
 
+/**
+ * Just get everything till the end of string.
+ */
+BEGINParser(Recursive) {
+
+    assert(str != NULL);
+    assert(offs != NULL);
+    assert(parsed != NULL);
+
+    int remaining_len = strLen - *offs;
+	const char *remaining_str = str + *offs;
+    
+    json_object *json_p = NULL;
+    json_object *unparsed = NULL;
+    CHKN(json_p = json_object_new_object());
+
+    ln_ctx ctx = (ln_ctx) node->parser_data;
+
+    ln_normalize(ctx, remaining_str, remaining_len, &json_p);
+
+    if (json_object_object_get_ex(json_p, UNPARSED_DATA_KEY, &unparsed)) {
+        json_object_put(json_p);
+        *parsed = 0;
+    } else {
+        *parsed = strLen - *offs;
+        *value = json_p;
+    }
+} ENDParser
+
+void* recursive_parser_data_constructor(ln_fieldList_t *node, ln_ctx ctx) { return ctx; }
+
+void recursive_parser_data_destructor(void** dataPtr) {};
 
 /**
  * Just get everything till the end of string.

--- a/src/parser.c
+++ b/src/parser.c
@@ -708,12 +708,12 @@ static void* _recursive_parser_data_constructor(ln_fieldList_t *node, ln_ctx ctx
 	r = 0;
 done:
 	if (r != 0) {
-		if (name == NULL) ln_dbgprintf(ctx, "couldn't allocate memory for recursive-field name");
+		if (name == NULL) ln_dbgprintf(ctx, "couldn't allocate memory for recursive/descent field name");
 		else if (pData == NULL) ln_dbgprintf(ctx, "couldn't allocate memory for parser-data for field: %s", name);
 		else if (args == NULL) ln_dbgprintf(ctx, "couldn't allocate memory for argument-parsing for field: %s", name);
-		else if (pData->ctx == NULL) ln_dbgprintf(ctx, "recursive normalizer context creation failed for field: %s", name);
+		else if (pData->ctx == NULL) ln_dbgprintf(ctx, "recursive/descent normalizer context creation failed for field: %s", name);
 		else if (pData->remaining_field == NULL) ln_dbgprintf(ctx, "couldn't allocate memory for remaining-field name for "
-															  "recursive field: %s", name);
+															  "recursive/descent field: %s", name);
 
 		recursive_parser_data_destructor((void**) &pData);
 	}
@@ -736,6 +736,7 @@ static ln_ctx child_recursive_parse_ctx_constructor(ln_ctx parent_ctx, pcons_arg
 	int r = LN_BADCONFIG;
 	const char* rb = NULL;
 	ln_ctx ctx = NULL;
+	pcons_unescape_arg(args, 0);
 	CHKN(rb = pcons_arg(args, 0, NULL));
 	CHKN(ctx = ln_inherittedCtx(parent_ctx));
 	CHKR(ln_loadSamples(ctx, rb));

--- a/src/parser.h
+++ b/src/parser.h
@@ -127,5 +127,12 @@ void* regex_parser_data_constructor(ln_fieldList_t *node, ln_ctx ctx);
 void regex_parser_data_destructor(void** dataPtr);
 #endif
 
+/** 
+ * Get all tokens separated by tokenizer-string as array.
+ */
+int ln_parseRecursive(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);
+
+void* recursive_parser_data_constructor(ln_fieldList_t *node, ln_ctx ctx);
+void recursive_parser_data_destructor(void** dataPtr);
 
 #endif /* #ifndef LIBLOGNORM_PARSER_H_INCLUDED */

--- a/src/parser.h
+++ b/src/parser.h
@@ -128,11 +128,12 @@ void regex_parser_data_destructor(void** dataPtr);
 #endif
 
 /** 
- * Match using the current rulebase all over again from current match position
+ * Match using the 'current' or 'separate rulebase' all over again from current match position
  */
 int ln_parseRecursive(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);
 
 void* recursive_parser_data_constructor(ln_fieldList_t *node, ln_ctx ctx);
+void* descent_parser_data_constructor(ln_fieldList_t *node, ln_ctx ctx);
 void recursive_parser_data_destructor(void** dataPtr);
 
 /** 

--- a/src/parser.h
+++ b/src/parser.h
@@ -128,11 +128,19 @@ void regex_parser_data_destructor(void** dataPtr);
 #endif
 
 /** 
- * Get all tokens separated by tokenizer-string as array.
+ * Match using the current rulebase all over again from current match position
  */
 int ln_parseRecursive(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);
 
 void* recursive_parser_data_constructor(ln_fieldList_t *node, ln_ctx ctx);
 void recursive_parser_data_destructor(void** dataPtr);
+
+/** 
+ * Get interpreted field 
+ */
+int ln_parseInterpret(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);
+
+void* interpret_parser_data_constructor(ln_fieldList_t *node, ln_ctx ctx);
+void interpret_parser_data_destructor(void** dataPtr);
 
 #endif /* #ifndef LIBLOGNORM_PARSER_H_INCLUDED */

--- a/src/ptree.c
+++ b/src/ptree.c
@@ -69,7 +69,7 @@ ln_newPTree(ln_ctx ctx, struct ln_ptree **parentptr)
 done:	return tree;
 }
 
-static void
+void
 ln_deletePTreeNode(ln_fieldList_t *node)
 {
 	ln_deletePTree(node->subtree);

--- a/src/ptree.c
+++ b/src/ptree.c
@@ -78,7 +78,7 @@ ln_deletePTreeNode(ln_fieldList_t *node)
 		es_deleteStr(node->data);
 	if(node->raw_data != NULL)
 		es_deleteStr(node->raw_data);
-	if(node->parser_data != NULL)
+	if(node->parser_data != NULL && node->parser_data_destructor != NULL)
 		node->parser_data_destructor(&(node->parser_data));
 	free(node);
 }
@@ -538,13 +538,13 @@ addUnparsedField(const char *str, size_t strLen, int offs, struct json_object *j
 	if (value == NULL) {
 		goto done;
 	}
-	json_object_object_add(json, "originalmsg", value);
+	json_object_object_add(json, ORIGINAL_MSG_KEY, value);
 	
 	value = json_object_new_string(s + offs);
 	if (value == NULL) {
 		goto done;
 	}
-	json_object_object_add(json, "unparsed-data", value);
+	json_object_object_add(json, UNPARSED_DATA_KEY, value);
 
 	r = 0;
 done:

--- a/src/ptree.h
+++ b/src/ptree.h
@@ -106,13 +106,20 @@ struct ln_ptree* ln_newPTree(ln_ctx ctx, struct ln_ptree** parent);
 
 
 /**
- * Free a parse tree node and destruct all members.
+ * Free a parse tree and destruct all members.
  * @memberof ln_ptree
  *
  * @param[in] tree pointer to ptree to free
  */
 void ln_deletePTree(struct ln_ptree *tree);
 
+/**
+ * Free a parse tree node and destruct all members.
+ * @memberof ln_ptree
+ *
+ * @param[in] node pointer to free
+ */
+void ln_deletePTreeNode(ln_fieldList_t *node);
 
 /**
  * Add a field description to the a tree.

--- a/src/ptree.h
+++ b/src/ptree.h
@@ -32,6 +32,9 @@
 #define	LIBLOGNORM_PTREE_H_INCLUDED
 #include <libestr.h>
 
+#define ORIGINAL_MSG_KEY "originalmsg"
+#define UNPARSED_DATA_KEY "unparsed-data"
+
 typedef struct ln_ptree ln_ptree; /**< the parse tree object */
 typedef struct ln_fieldList_s ln_fieldList_t;
 

--- a/src/samp.c
+++ b/src/samp.c
@@ -224,6 +224,10 @@ ln_parseFieldDescr(ln_ctx ctx, es_str_t *rule, es_size_t *bufOffs, es_str_t **st
         node->parser = ln_parseRecursive;
         constructor_fn = recursive_parser_data_constructor;
         node->parser_data_destructor = recursive_parser_data_destructor;
+    } else if (!es_strconstcmp(*str, "descent")) {
+        node->parser = ln_parseRecursive;
+        constructor_fn = descent_parser_data_constructor;
+        node->parser_data_destructor = recursive_parser_data_destructor;
     } else if (!es_strconstcmp(*str, "interpret")) {
         node->parser = ln_parseInterpret;
         constructor_fn = interpret_parser_data_constructor;

--- a/src/samp.c
+++ b/src/samp.c
@@ -210,7 +210,11 @@ parseFieldDescr(ln_ctx ctx, struct ln_ptree **subtree, es_str_t *rule,
 		node->parser_data_destructor = regex_parser_data_destructor;
 	}
 #endif
-	else {
+    else if (!es_strconstcmp(*str, "recursive")) {
+        node->parser = ln_parseRecursive;
+        constructor_fn = recursive_parser_data_constructor;
+        node->parser_data_destructor = recursive_parser_data_destructor;
+    } else {
 		cstr = es_str2cstr(*str, NULL);
 		ln_dbgprintf(ctx, "ERROR: invalid field type '%s'", cstr);
 		free(cstr);

--- a/src/samp.c
+++ b/src/samp.c
@@ -224,6 +224,10 @@ ln_parseFieldDescr(ln_ctx ctx, es_str_t *rule, es_size_t *bufOffs, es_str_t **st
         node->parser = ln_parseRecursive;
         constructor_fn = recursive_parser_data_constructor;
         node->parser_data_destructor = recursive_parser_data_destructor;
+    } else if (!es_strconstcmp(*str, "interpret")) {
+        node->parser = ln_parseInterpret;
+        constructor_fn = interpret_parser_data_constructor;
+        node->parser_data_destructor = interpret_parser_data_destructor;
     } else {
 		cstr = es_str2cstr(*str, NULL);
 		ln_dbgprintf(ctx, "ERROR: invalid field type '%s'", cstr);

--- a/src/samp.h
+++ b/src/samp.h
@@ -114,4 +114,21 @@ ln_sampRead(ln_ctx ctx, struct ln_sampRepos *repo, int *isEof);
 void
 ln_sampFree(ln_ctx ctx, struct ln_samp *samp);
 
+
+/**
+ * Parse a given sample
+ *
+ * @param[in] ctx current library context
+ * @param[in] rule string (with prefix and suffix '%' markers)
+ * @param[in] offset in rule-string to start at (it should be pointed to
+ *  starting character: '%')
+ * @param[in] temp string buffer(working space),
+ *  externalized for efficiency reasons
+ * @param[out] return code (0 means success)
+ * @return newly created node, which can be added to sample tree.
+ */
+ln_fieldList_t*
+ln_parseFieldDescr(ln_ctx ctx, es_str_t *rule, es_size_t *bufOffs,
+				   es_str_t **str, int* ret);
+
 #endif /* #ifndef LIBLOGNORM_SAMPLES_H_INCLUDED */

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,3 @@
+*.o
+json_eq
+.deps

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -2,3 +2,4 @@
 json_eq
 .deps
 core
+*.rulebase

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,4 @@
 *.o
 json_eq
 .deps
+core

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -3,3 +3,4 @@ json_eq
 .deps
 core
 *.rulebase
+vgcore.*

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -9,7 +9,8 @@ TESTS = \
 	field_tokenized_with_invalid_ruledef.sh \
 	field_recursive.sh \
 	field_tokenized_recursive.sh \
-	field_interpret.sh
+	field_interpret.sh \
+	field_interpret_with_invalid_ruledef.sh
 
 if ENABLE_REGEXP
 TESTS +=  \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,13 @@
+check_PROGRAMS = json_eq
+json_eq_SOURCES = json_eq.c $(top_srcdir)/src/json_compatibility.c
+json_eq_CPPFLAGS =  $(JSON_C_CFLAGS) -I$(top_srcdir)/src
+json_eq_LDADD = $(JSON_C_LIBS)
+json_eq_LDFLAGS = -no-install
+
 TESTS = \
 	field_tokenized.sh \
-	field_tokenized_with_invalid_ruledef.sh
+	field_tokenized_with_invalid_ruledef.sh \
+	field_recursive.sh
 
 if ENABLE_REGEXP
 TESTS +=  \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -8,7 +8,8 @@ TESTS = \
 	field_tokenized.sh \
 	field_tokenized_with_invalid_ruledef.sh \
 	field_recursive.sh \
-	field_tokenized_recursive.sh
+	field_tokenized_recursive.sh \
+	field_interpret.sh
 
 if ENABLE_REGEXP
 TESTS +=  \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -10,7 +10,9 @@ TESTS = \
 	field_recursive.sh \
 	field_tokenized_recursive.sh \
 	field_interpret.sh \
-	field_interpret_with_invalid_ruledef.sh
+	field_interpret_with_invalid_ruledef.sh \
+	field_descent.sh \
+	field_descent_with_invalid_ruledef.sh
 
 if ENABLE_REGEXP
 TESTS +=  \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,7 +7,8 @@ json_eq_LDFLAGS = -no-install
 TESTS = \
 	field_tokenized.sh \
 	field_tokenized_with_invalid_ruledef.sh \
-	field_recursive.sh
+	field_recursive.sh \
+	field_tokenized_recursive.sh
 
 if ENABLE_REGEXP
 TESTS +=  \

--- a/tests/exec.sh
+++ b/tests/exec.sh
@@ -12,6 +12,8 @@ source ./options.sh
 
 function execute() {
     echo $1 | $cmd $ln_opts -r tmp.rulebase -e json > test.out 
+    echo "Out:"
+    cat test.out
 }
 
 function assert_output_contains() {

--- a/tests/exec.sh
+++ b/tests/exec.sh
@@ -18,6 +18,11 @@ function assert_output_contains() {
     cat test.out | grep -F "$1"
 }
 
+function assert_output_json_eq() {
+    ./json_eq "$1" "$(cat test.out)"
+}
+
+
 function reset_rules() {
     rm -f tmp.rulebase
 }

--- a/tests/exec.sh
+++ b/tests/exec.sh
@@ -5,15 +5,25 @@ echo ===========================================================================
 echo "[${test_file}]: test for ${2}"
 
 set -e
+ulimit -c unlimited
 
 cmd=../src/ln_test
 
 source ./options.sh
 
 function execute() {
+    if [ "x$debug" == "xon" ]; then
+	echo "======rulebase======="
+	cat tmp.rulebase
+	echo "====================="
+	set -x
+    fi
     echo $1 | $cmd $ln_opts -r tmp.rulebase -e json > test.out 
     echo "Out:"
     cat test.out
+    if [ "x$debug" == "xon" ]; then
+	set +x
+    fi
 }
 
 function assert_output_contains() {

--- a/tests/exec.sh
+++ b/tests/exec.sh
@@ -5,7 +5,9 @@ echo ===========================================================================
 echo "[${test_file}]: test for ${2}"
 
 set -e
-ulimit -c unlimited
+if [ "x$debug" == "xon" ]; then #get core-dump on crash
+    ulimit -c unlimited
+fi
 
 cmd=../src/ln_test
 

--- a/tests/exec.sh
+++ b/tests/exec.sh
@@ -36,13 +36,22 @@ function assert_output_json_eq() {
     ./json_eq "$1" "$(cat test.out)"
 }
 
+function rulebase_file_name() {
+    if [ "x$1" == "x" ]; then
+	echo tmp.rulebase
+    else
+	echo $1.rulebase
+    fi
+}
 
 function reset_rules() {
-    rm -f tmp.rulebase
+    local rb_file=$(rulebase_file_name $1)
+    rm -f $rb_file
 }
 
 function add_rule() {
-    echo $1 >> tmp.rulebase
+    local rb_file=$(rulebase_file_name $2)
+    echo $1 >> $rb_file
 }
 
 reset_rules

--- a/tests/field_descent.sh
+++ b/tests/field_descent.sh
@@ -58,3 +58,12 @@ assert_output_json_eq '{"op": {"action": "blocked", "net": {"ip_addr": "10.20.30
 execute '10.20.30.40/16 unblocked on gw-2'
 assert_output_json_eq '{"op": {"action": "unblocked", "net": {"subnet_addr": "10.20.30.40", "mask": "16"}}, "device": "gw-2"}'
 
+#descent with file name having lognorm special char
+add_rule 'rule=:blocked on %device:word% %net:descent:'$srcdir'/part\x3anet.rulebase%at %tm:date-rfc5424%'
+reset_rules 'part:net'
+add_rule 'rule=:%ip_addr:ipv4% %tail:rest%' 'part:net'
+add_rule 'rule=:%subnet_addr:ipv4%/%mask:number% %tail:rest%' 'part:net'
+execute 'blocked on gw-1 10.20.30.40 at 2014-12-08T08:53:33.05+05:30'
+assert_output_json_eq '{"device": "gw-1", "net": {"ip_addr": "10.20.30.40"}, "tm": "2014-12-08T08:53:33.05+05:30"}'
+execute 'blocked on gw-1 10.20.30.40/16 at 2014-12-08T08:53:33.05+05:30'
+assert_output_json_eq '{"device": "gw-1", "net": {"subnet_addr": "10.20.30.40", "mask": "16"}, "tm": "2014-12-08T08:53:33.05+05:30"}'

--- a/tests/field_descent.sh
+++ b/tests/field_descent.sh
@@ -1,0 +1,60 @@
+# added 2014-12-11 by singh.janmejay
+# This file is part of the liblognorm project, released under ASL 2.0
+source ./exec.sh $0 "descent based parsing field"
+
+#descent with default tail field
+add_rule 'rule=:blocked on %device:word% %net:descent:'$srcdir'/child.rulebase%at %tm:date-rfc5424%'
+reset_rules 'child'
+add_rule 'rule=:%ip_addr:ipv4% %tail:rest%' 'child'
+add_rule 'rule=:%subnet_addr:ipv4%/%mask:number% %tail:rest%' 'child'
+execute 'blocked on gw-1 10.20.30.40 at 2014-12-08T08:53:33.05+05:30'
+assert_output_json_eq '{"device": "gw-1", "net": {"ip_addr": "10.20.30.40"}, "tm": "2014-12-08T08:53:33.05+05:30"}'
+execute 'blocked on gw-1 10.20.30.40/16 at 2014-12-08T08:53:33.05+05:30'
+assert_output_json_eq '{"device": "gw-1", "net": {"subnet_addr": "10.20.30.40", "mask": "16"}, "tm": "2014-12-08T08:53:33.05+05:30"}'
+
+#descent with tail field being explicitly named 'tail'
+reset_rules
+add_rule 'rule=:blocked on %device:word% %net:descent:'$srcdir'/field.rulebase:tail%at %tm:date-rfc5424%'
+reset_rules 'field'
+add_rule 'rule=:%ip_addr:ipv4% %tail:rest%' 'field'
+add_rule 'rule=:%subnet_addr:ipv4%/%mask:number% %tail:rest%' 'field'
+execute 'blocked on gw-1 10.20.30.40 at 2014-12-08T08:53:33.05+05:30'
+assert_output_json_eq '{"device": "gw-1", "net": {"ip_addr": "10.20.30.40"}, "tm": "2014-12-08T08:53:33.05+05:30"}'
+execute 'blocked on gw-1 10.20.30.40/16 at 2014-12-08T08:53:33.05+05:30'
+assert_output_json_eq '{"device": "gw-1", "net": {"subnet_addr": "10.20.30.40", "mask": "16"}, "tm": "2014-12-08T08:53:33.05+05:30"}'
+
+#descent with tail field having arbirary name
+reset_rules
+add_rule 'rule=:blocked on %device:word% %net:descent:'$srcdir'/subset.rulebase:remaining%at %tm:date-rfc5424%'
+reset_rules 'subset'
+add_rule 'rule=:%ip_addr:ipv4% %remaining:rest%' 'subset'
+add_rule 'rule=:%subnet_addr:ipv4%/%mask:number% %remaining:rest%' 'subset'
+execute 'blocked on gw-1 10.20.30.40 at 2014-12-08T08:53:33.05+05:30'
+assert_output_json_eq '{"device": "gw-1", "net": {"ip_addr": "10.20.30.40"}, "tm": "2014-12-08T08:53:33.05+05:30"}'
+execute 'blocked on gw-1 10.20.30.40/16 at 2014-12-08T08:53:33.05+05:30'
+assert_output_json_eq '{"device": "gw-1", "net": {"subnet_addr": "10.20.30.40", "mask": "16"}, "tm": "2014-12-08T08:53:33.05+05:30"}'
+
+#head call handling with with separate rulebase and tail field with with arbitrary name (this is what recursive field can't do)
+reset_rules
+add_rule 'rule=:%net:descent:'$srcdir'/alt.rulebase:remains%blocked on %device:word%'
+reset_rules 'alt'
+add_rule 'rule=:%ip_addr:ipv4% %remains:rest%' 'alt'
+add_rule 'rule=:%subnet_addr:ipv4%/%mask:number% %remains:rest%' 'alt'
+execute '10.20.30.40 blocked on gw-1'
+assert_output_json_eq '{"device": "gw-1", "net": {"ip_addr": "10.20.30.40"}}'
+execute '10.20.30.40/16 blocked on gw-1'
+assert_output_json_eq '{"device": "gw-1", "net": {"subnet_addr": "10.20.30.40", "mask": "16"}}'
+
+#descent-field which calls another descent-field
+reset_rules
+add_rule 'rule=:%op:descent:'$srcdir'/op.rulebase:rest% on %device:word%'
+reset_rules 'op'
+add_rule 'rule=:%net:descent:'$srcdir'/alt.rulebase:remains%%action:word%%rest:rest%' 'op'
+reset_rules 'alt'
+add_rule 'rule=:%ip_addr:ipv4% %remains:rest%' 'alt'
+add_rule 'rule=:%subnet_addr:ipv4%/%mask:number% %remains:rest%' 'alt'
+execute '10.20.30.40 blocked on gw-1'
+assert_output_json_eq '{"op": {"action": "blocked", "net": {"ip_addr": "10.20.30.40"}}, "device": "gw-1"}'
+execute '10.20.30.40/16 unblocked on gw-2'
+assert_output_json_eq '{"op": {"action": "unblocked", "net": {"subnet_addr": "10.20.30.40", "mask": "16"}}, "device": "gw-2"}'
+

--- a/tests/field_descent_with_invalid_ruledef.sh
+++ b/tests/field_descent_with_invalid_ruledef.sh
@@ -1,0 +1,79 @@
+# added 2014-12-15 by singh.janmejay
+# This file is part of the liblognorm project, released under ASL 2.0
+source ./exec.sh $0 "descent based parsing field, with invalid ruledef"
+
+#invalid parent field name
+add_rule 'rule=:%net:desce%'
+execute '10.20.30.40 foo'
+assert_output_json_eq '{ "originalmsg": "10.20.30.40 foo", "unparsed-data": "10.20.30.40 foo" }'
+
+#no args
+add_rule 'rule=:%net:descent%'
+execute '10.20.30.40 foo'
+assert_output_json_eq '{ "originalmsg": "10.20.30.40 foo", "unparsed-data": "10.20.30.40 foo" }'
+
+#incorrect rulebase file path
+rm -f $srcdir/quux.rulebase
+add_rule 'rule=:%net:descent:'$srcdir'/quux.rulebase%'
+execute '10.20.30.40 foo'
+assert_output_json_eq '{ "originalmsg": "10.20.30.40 foo", "unparsed-data": "10.20.30.40 foo" }'
+
+#invalid content in rulebase file
+reset_rules
+add_rule 'rule=:%net:descent:'$srcdir'/child.rulebase%'
+reset_rules 'child'
+add_rule 'rule=:%ip_addr:ipv4 %tail:rest%' 'child'
+execute '10.20.30.40 foo'
+assert_output_json_eq '{ "originalmsg": "10.20.30.40 foo", "unparsed-data": "10.20.30.40 foo" }'
+
+#empty child rulebase file
+reset_rules
+add_rule 'rule=:%net:descent:'$srcdir'/child.rulebase%'
+reset_rules 'child'
+execute '10.20.30.40 foo'
+assert_output_json_eq '{ "originalmsg": "10.20.30.40 foo", "unparsed-data": "10.20.30.40 foo" }'
+
+#no rulebase given
+reset_rules
+add_rule 'rule=:%net:descent:'
+reset_rules 'child'
+execute '10.20.30.40 foo'
+assert_output_json_eq '{ "originalmsg": "10.20.30.40 foo", "unparsed-data": "10.20.30.40 foo" }'
+
+#no rulebase and no tail-field given
+reset_rules
+add_rule 'rule=:%net:descent::'
+reset_rules 'child'
+execute '10.20.30.40 foo'
+assert_output_json_eq '{ "originalmsg": "10.20.30.40 foo", "unparsed-data": "10.20.30.40 foo" }'
+
+#no rulebase given, but has valid tail-field
+reset_rules
+add_rule 'rule=:%net:descent::foo'
+reset_rules 'child'
+execute '10.20.30.40 foo'
+assert_output_json_eq '{ "originalmsg": "10.20.30.40 foo", "unparsed-data": "10.20.30.40 foo" }'
+
+#empty tail-field given
+reset_rules
+add_rule 'rule=:%net:descent:'$srcdir'/child.rulebase:%'
+reset_rules 'child'
+add_rule 'rule=:%ip_addr:ipv4% %tail:rest%' 'child'
+execute '10.20.30.40 foo'
+assert_output_json_eq '{ "net": { "tail": "foo", "ip_addr": "10.20.30.40" } }'
+
+#named tail-field not populated
+reset_rules
+add_rule 'rule=:%net:descent:'$srcdir'/child.rulebase:foo% foo'
+reset_rules 'child'
+add_rule 'rule=:%ip_addr:ipv4% %tail:rest%' 'child'
+execute '10.20.30.40 foo'
+assert_output_json_eq '{ "originalmsg": "10.20.30.40 foo", "unparsed-data": "" }'
+
+#named tail-field not populated
+reset_rules
+add_rule 'rule=:%net:descent:'$srcdir'/child.rulebase:foo% foo'
+reset_rules 'child'
+add_rule 'rule=:%ip_addr:ipv4% %tail:rest%' 'child'
+execute '10.20.30.40 foo'
+assert_output_json_eq '{ "originalmsg": "10.20.30.40 foo", "unparsed-data": "" }'

--- a/tests/field_interpret.sh
+++ b/tests/field_interpret.sh
@@ -1,0 +1,14 @@
+# added 2014-12-11 by singh.janmejay
+# This file is part of the liblognorm project, released under ASL 2.0
+source ./exec.sh $0 "value interpreting field"
+
+add_rule 'rule=:rule=:%session_count:interpret:int:word% sessions established'
+execute '64 sessions established'
+assert_output_json_eq '{"sessions_count": 64}'
+
+reset_rules
+add_rule 'rule=:record count for shard [%shard:interpret:base16int:char-to:]%] is %record_count:interpret:base10int:word% and %latency_percentile:interpret:float:word%\x37ile latency is %latency:interpret:float:word% %latency_unit:word%'
+execute 'record count for shard [3F] is 50000 and 99.99%ile latency is 2.1 seconds'
+assert_output_json_eq '{"shard": 63, "record_count": 50000, "latency_percentile": 99.99, "latency": 2.1, "latency_unit" : "seconds"}'
+
+

--- a/tests/field_interpret.sh
+++ b/tests/field_interpret.sh
@@ -35,3 +35,12 @@ add_rule 'rule=:%latency_percentile:interpret:float:char-to:\x25%\x25ile latency
 execute '98%ile latency is 1.999123'
 assert_output_json_eq '{"latency_percentile": 98.0, "latency": 1.999123}'
 
+reset_rules
+add_rule 'rule=:%latency_percentile:interpret:float:number%'
+add_rule 'rule=:%latency_percentile:interpret:int:number%'
+add_rule 'rule=:%latency_percentile:interpret:base16int:number%'
+add_rule 'rule=:%latency_percentile:interpret:base10int:number%'
+add_rule 'rule=:%latency_percentile:interpret:boolean:number%'
+execute 'foo'
+assert_output_json_eq '{ "originalmsg": "foo", "unparsed-data": "foo" }'
+

--- a/tests/field_interpret.sh
+++ b/tests/field_interpret.sh
@@ -26,7 +26,7 @@ execute 'max sessions limit reached: NO'
 assert_output_json_eq '{"at_limit": false}'
 
 reset_rules
-add_rule 'rule=:record count for shard [%shard:interpret:base16int:char-to:]%] is %record_count:interpret:base10int:word% and %latency_percentile:interpret:float:char-to:\x25%\x25ile latency is %latency:interpret:float:word% %latency_unit:word%'
+add_rule 'rule=:record count for shard [%shard:interpret:base16int:char-to:]%] is %record_count:interpret:base10int:number% and %latency_percentile:interpret:float:char-to:\x25%\x25ile latency is %latency:interpret:float:word% %latency_unit:word%'
 execute 'record count for shard [3F] is 50000 and 99.99%ile latency is 2.1 seconds'
 assert_output_json_eq '{"shard": 63, "record_count": 50000, "latency_percentile": 99.99, "latency": 2.1, "latency_unit" : "seconds"}'
 

--- a/tests/field_interpret.sh
+++ b/tests/field_interpret.sh
@@ -2,13 +2,36 @@
 # This file is part of the liblognorm project, released under ASL 2.0
 source ./exec.sh $0 "value interpreting field"
 
-add_rule 'rule=:rule=:%session_count:interpret:int:word% sessions established'
+add_rule 'rule=:%session_count:interpret:int:word% sessions established'
 execute '64 sessions established'
-assert_output_json_eq '{"sessions_count": 64}'
+assert_output_json_eq '{"session_count": 64}'
 
 reset_rules
-add_rule 'rule=:record count for shard [%shard:interpret:base16int:char-to:]%] is %record_count:interpret:base10int:word% and %latency_percentile:interpret:float:word%\x37ile latency is %latency:interpret:float:word% %latency_unit:word%'
+add_rule 'rule=:max sessions limit reached: %at_limit:interpret:bool:word%'
+execute 'max sessions limit reached: true'
+assert_output_json_eq '{"at_limit": true}'
+execute 'max sessions limit reached: false'
+assert_output_json_eq '{"at_limit": false}'
+execute 'max sessions limit reached: TRUE'
+assert_output_json_eq '{"at_limit": true}'
+execute 'max sessions limit reached: FALSE'
+assert_output_json_eq '{"at_limit": false}'
+execute 'max sessions limit reached: yes'
+assert_output_json_eq '{"at_limit": true}'
+execute 'max sessions limit reached: no'
+assert_output_json_eq '{"at_limit": false}'
+execute 'max sessions limit reached: YES'
+assert_output_json_eq '{"at_limit": true}'
+execute 'max sessions limit reached: NO'
+assert_output_json_eq '{"at_limit": false}'
+
+reset_rules
+add_rule 'rule=:record count for shard [%shard:interpret:base16int:char-to:]%] is %record_count:interpret:base10int:word% and %latency_percentile:interpret:float:char-to:\x25%\x25ile latency is %latency:interpret:float:word% %latency_unit:word%'
 execute 'record count for shard [3F] is 50000 and 99.99%ile latency is 2.1 seconds'
 assert_output_json_eq '{"shard": 63, "record_count": 50000, "latency_percentile": 99.99, "latency": 2.1, "latency_unit" : "seconds"}'
 
+reset_rules
+add_rule 'rule=:%latency_percentile:interpret:float:char-to:\x25%\x25ile latency is %latency:interpret:float:word%'
+execute '98%ile latency is 1.999123'
+assert_output_json_eq '{"latency_percentile": 98.0, "latency": 1.999123}'
 

--- a/tests/field_interpret_with_invalid_ruledef.sh
+++ b/tests/field_interpret_with_invalid_ruledef.sh
@@ -1,0 +1,53 @@
+# added 2014-12-11 by singh.janmejay
+# This file is part of the liblognorm project, released under ASL 2.0
+source ./exec.sh $0 "value interpreting field, with invalid ruledef"
+
+add_rule 'rule=:%session_count:interpret:int:wd% sessions established'
+execute '64 sessions established'
+assert_output_json_eq '{ "originalmsg": "64 sessions established", "unparsed-data": "64 sessions established" }'
+
+reset_rules
+add_rule 'rule=:%session_count:interpret:int:% sessions established'
+execute '64 sessions established'
+assert_output_json_eq '{ "originalmsg": "64 sessions established", "unparsed-data": "64 sessions established" }'
+
+reset_rules
+add_rule 'rule=:%session_count:interpret:int% sessions established'
+execute '64 sessions established'
+assert_output_json_eq '{ "originalmsg": "64 sessions established", "unparsed-data": "64 sessions established" }'
+
+reset_rules
+add_rule 'rule=:%session_count:interpret:in% sessions established'
+execute '64 sessions established'
+assert_output_json_eq '{ "originalmsg": "64 sessions established", "unparsed-data": "64 sessions established" }'
+
+reset_rules
+add_rule 'rule=:%session_count:interpret:in:word% sessions established'
+execute '64 sessions established'
+assert_output_json_eq '{ "originalmsg": "64 sessions established", "unparsed-data": "64 sessions established" }'
+
+reset_rules
+add_rule 'rule=:%session_count:interpret:in:wd% sessions established'
+execute '64 sessions established'
+assert_output_json_eq '{ "originalmsg": "64 sessions established", "unparsed-data": "64 sessions established" }'
+
+reset_rules
+add_rule 'rule=:%session_count:interpret::word% sessions established'
+execute '64 sessions established'
+assert_output_json_eq '{ "originalmsg": "64 sessions established", "unparsed-data": "64 sessions established" }'
+
+reset_rules
+add_rule 'rule=:%session_count:interpret::% sessions established'
+execute '64 sessions established'
+assert_output_json_eq '{ "originalmsg": "64 sessions established", "unparsed-data": "64 sessions established" }'
+
+reset_rules
+add_rule 'rule=:%session_count:inter::% sessions established'
+execute '64 sessions established'
+assert_output_json_eq '{ "originalmsg": "64 sessions established", "unparsed-data": "64 sessions established" }'
+
+reset_rules
+add_rule 'rule=:%session_count:inter:int:word% sessions established'
+execute '64 sessions established'
+assert_output_json_eq '{ "originalmsg": "64 sessions established", "unparsed-data": "64 sessions established" }'
+

--- a/tests/field_recursive.sh
+++ b/tests/field_recursive.sh
@@ -7,3 +7,21 @@ add_rule 'rule=:%word:word% %next:recursive%'
 add_rule 'rule=:%word:word%'
 execute '123 abc 456 def'
 assert_output_json_eq '{"word": "123", "next": {"word": "abc", "next": {"word": "456", "next" : {"word": "def"}}}}'
+
+reset_rules
+
+debug=on
+add_rule 'rule=:%subnet_addr:ipv4%/%subnet_mask:number%%tail:rest%'
+add_rule 'rule=:%ip_addr:ipv4%%tail:rest%'
+add_rule 'rule=:blocked inbound via: %via_ip:ipv4% from: %addresses:tokenized:, :recursive% to %server_ip:ipv4%'
+execute 'blocked inbound via: 192.168.1.1 from: 1.2.3.4, 5.6.16.0/12, 8.9.10.11, 12.13.14.15, 16.17.18.0/8, 19.20.21.24/3 to 192.168.1.5'
+assert_output_json_eq '{
+"addresses": [
+  {"ip_addr": "1.2.3.4"}, 
+  {"subnet_addr": "5.6.16.0", "subnet_mask": "12"}, 
+  {"ip_addr": "8.9.10.11"}, 
+  {"ip_addr": "12.13.14.15"}, 
+  {"subnet_addr": "16.17.18.0", "subnet_mask": "8"}, 
+  {"subnet_addr": "19.20.21.24", "subnet_mask": "3"}], 
+"server_ip": "192.168.1.5",
+"via_ip": "192.168.1.1"}'

--- a/tests/field_recursive.sh
+++ b/tests/field_recursive.sh
@@ -1,19 +1,38 @@
 # added 2014-11-26 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
 
+debug=on
 source ./exec.sh $0 "recursive parsing field"
 
+#with default tail field
 add_rule 'rule=:%word:word% %next:recursive%'
 add_rule 'rule=:%word:word%'
 execute '123 abc 456 def'
 assert_output_json_eq '{"word": "123", "next": {"word": "abc", "next": {"word": "456", "next" : {"word": "def"}}}}'
 
+#recursive field inside tokenized field with default tail field
 reset_rules
-
-debug=on
 add_rule 'rule=:%subnet_addr:ipv4%/%subnet_mask:number%%tail:rest%'
 add_rule 'rule=:%ip_addr:ipv4%%tail:rest%'
 add_rule 'rule=:blocked inbound via: %via_ip:ipv4% from: %addresses:tokenized:, :recursive% to %server_ip:ipv4%'
+execute 'blocked inbound via: 192.168.1.1 from: 1.2.3.4, 5.6.16.0/12, 8.9.10.11, 12.13.14.15, 16.17.18.0/8, 19.20.21.24/3 to 192.168.1.5'
+assert_output_json_eq '{
+"addresses": [
+  {"ip_addr": "1.2.3.4"}, 
+  {"subnet_addr": "5.6.16.0", "subnet_mask": "12"}, 
+  {"ip_addr": "8.9.10.11"}, 
+  {"ip_addr": "12.13.14.15"}, 
+  {"subnet_addr": "16.17.18.0", "subnet_mask": "8"}, 
+  {"subnet_addr": "19.20.21.24", "subnet_mask": "3"}], 
+"server_ip": "192.168.1.5",
+"via_ip": "192.168.1.1"}'
+reset_rules
+
+#recursive field inside tokenized field with default tail field
+reset_rules
+add_rule 'rule=:%subnet_addr:ipv4%/%subnet_mask:number%%remains:rest%'
+add_rule 'rule=:%ip_addr:ipv4%%remains:rest%'
+add_rule 'rule=:blocked inbound via: %via_ip:ipv4% from: %addresses:tokenized:, :recursive:remains% to %server_ip:ipv4%'
 execute 'blocked inbound via: 192.168.1.1 from: 1.2.3.4, 5.6.16.0/12, 8.9.10.11, 12.13.14.15, 16.17.18.0/8, 19.20.21.24/3 to 192.168.1.5'
 assert_output_json_eq '{
 "addresses": [

--- a/tests/field_recursive.sh
+++ b/tests/field_recursive.sh
@@ -1,46 +1,54 @@
 # added 2014-11-26 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
-
-debug=on
 source ./exec.sh $0 "recursive parsing field"
 
-#with default tail field
+#tail recursion with default tail field
 add_rule 'rule=:%word:word% %next:recursive%'
 add_rule 'rule=:%word:word%'
 execute '123 abc 456 def'
 assert_output_json_eq '{"word": "123", "next": {"word": "abc", "next": {"word": "456", "next" : {"word": "def"}}}}'
 
-#recursive field inside tokenized field with default tail field
+#tail recursion with explicitly named 'tail' field
 reset_rules
-add_rule 'rule=:%subnet_addr:ipv4%/%subnet_mask:number%%tail:rest%'
-add_rule 'rule=:%ip_addr:ipv4%%tail:rest%'
-add_rule 'rule=:blocked inbound via: %via_ip:ipv4% from: %addresses:tokenized:, :recursive% to %server_ip:ipv4%'
-execute 'blocked inbound via: 192.168.1.1 from: 1.2.3.4, 5.6.16.0/12, 8.9.10.11, 12.13.14.15, 16.17.18.0/8, 19.20.21.24/3 to 192.168.1.5'
-assert_output_json_eq '{
-"addresses": [
-  {"ip_addr": "1.2.3.4"}, 
-  {"subnet_addr": "5.6.16.0", "subnet_mask": "12"}, 
-  {"ip_addr": "8.9.10.11"}, 
-  {"ip_addr": "12.13.14.15"}, 
-  {"subnet_addr": "16.17.18.0", "subnet_mask": "8"}, 
-  {"subnet_addr": "19.20.21.24", "subnet_mask": "3"}], 
-"server_ip": "192.168.1.5",
-"via_ip": "192.168.1.1"}'
-reset_rules
+add_rule 'rule=:%word:word% %next:recursive:tail%'
+add_rule 'rule=:%word:word%'
+execute '123 abc 456 def'
+assert_output_json_eq '{"word": "123", "next": {"word": "abc", "next": {"word": "456", "next" : {"word": "def"}}}}'
 
-#recursive field inside tokenized field with default tail field
+#tail recursion with tail field having arbirary name
 reset_rules
-add_rule 'rule=:%subnet_addr:ipv4%/%subnet_mask:number%%remains:rest%'
-add_rule 'rule=:%ip_addr:ipv4%%remains:rest%'
-add_rule 'rule=:blocked inbound via: %via_ip:ipv4% from: %addresses:tokenized:, :recursive:remains% to %server_ip:ipv4%'
-execute 'blocked inbound via: 192.168.1.1 from: 1.2.3.4, 5.6.16.0/12, 8.9.10.11, 12.13.14.15, 16.17.18.0/8, 19.20.21.24/3 to 192.168.1.5'
-assert_output_json_eq '{
-"addresses": [
-  {"ip_addr": "1.2.3.4"}, 
-  {"subnet_addr": "5.6.16.0", "subnet_mask": "12"}, 
-  {"ip_addr": "8.9.10.11"}, 
-  {"ip_addr": "12.13.14.15"}, 
-  {"subnet_addr": "16.17.18.0", "subnet_mask": "8"}, 
-  {"subnet_addr": "19.20.21.24", "subnet_mask": "3"}], 
-"server_ip": "192.168.1.5",
-"via_ip": "192.168.1.1"}'
+add_rule 'rule=:%word:word% %next:recursive:foo%'
+add_rule 'rule=:%word:word%'
+execute '123 abc 456 def'
+assert_output_json_eq '{"word": "123", "next": {"word": "abc", "next": {"word": "456", "next" : {"word": "def"}}}}'
+
+#non tail recursion with default tail field 
+reset_rules
+add_rule 'rule=:blocked on %device:word% %net:recursive%at %tm:date-rfc5424%'
+add_rule 'rule=:%ip_addr:ipv4% %tail:rest%'
+add_rule 'rule=:%subnet_addr:ipv4%/%mask:number% %tail:rest%'
+execute 'blocked on gw-1 10.20.30.40 at 2014-12-08T08:53:33.05+05:30'
+assert_output_json_eq '{"device": "gw-1", "net": {"ip_addr": "10.20.30.40"}, "tm": "2014-12-08T08:53:33.05+05:30"}'
+execute 'blocked on gw-1 10.20.30.40/16 at 2014-12-08T08:53:33.05+05:30'
+assert_output_json_eq '{"device": "gw-1", "net": {"subnet_addr": "10.20.30.40", "mask": "16"}, "tm": "2014-12-08T08:53:33.05+05:30"}'
+
+#non tail recursion with tail field being explicitly named 'tail'
+reset_rules
+add_rule 'rule=:blocked on %device:word% %net:recursive:tail%at %tm:date-rfc5424%'
+add_rule 'rule=:%ip_addr:ipv4% %tail:rest%'
+add_rule 'rule=:%subnet_addr:ipv4%/%mask:number% %tail:rest%'
+execute 'blocked on gw-1 10.20.30.40 at 2014-12-08T08:53:33.05+05:30'
+assert_output_json_eq '{"device": "gw-1", "net": {"ip_addr": "10.20.30.40"}, "tm": "2014-12-08T08:53:33.05+05:30"}'
+execute 'blocked on gw-1 10.20.30.40/16 at 2014-12-08T08:53:33.05+05:30'
+assert_output_json_eq '{"device": "gw-1", "net": {"subnet_addr": "10.20.30.40", "mask": "16"}, "tm": "2014-12-08T08:53:33.05+05:30"}'
+
+#non tail recursion with tail field having arbirary name
+reset_rules
+add_rule 'rule=:blocked on %device:word% %net:recursive:remaining%at %tm:date-rfc5424%'
+add_rule 'rule=:%ip_addr:ipv4% %remaining:rest%'
+add_rule 'rule=:%subnet_addr:ipv4%/%mask:number% %remaining:rest%'
+execute 'blocked on gw-1 10.20.30.40 at 2014-12-08T08:53:33.05+05:30'
+assert_output_json_eq '{"device": "gw-1", "net": {"ip_addr": "10.20.30.40"}, "tm": "2014-12-08T08:53:33.05+05:30"}'
+execute 'blocked on gw-1 10.20.30.40/16 at 2014-12-08T08:53:33.05+05:30'
+assert_output_json_eq '{"device": "gw-1", "net": {"subnet_addr": "10.20.30.40", "mask": "16"}, "tm": "2014-12-08T08:53:33.05+05:30"}'
+

--- a/tests/field_recursive.sh
+++ b/tests/field_recursive.sh
@@ -1,0 +1,9 @@
+# added 2014-11-26 by singh.janmejay
+# This file is part of the liblognorm project, released under ASL 2.0
+
+source ./exec.sh $0 "recursive parsing field"
+
+add_rule 'rule=:%word:word% %next:recursive%'
+add_rule 'rule=:%word:word%'
+execute '123 abc 456 def'
+assert_output_json_eq '{"word": "123", "next": {"word": "abc", "next": {"word": "456", "next" : {"word": "def"}}}}'

--- a/tests/field_tokenized.sh
+++ b/tests/field_tokenized.sh
@@ -5,11 +5,13 @@ add_rule 'rule=:%arr:tokenized: , :word% %more:rest%'
 execute '123 , abc , 456 , def ijk789'
 assert_output_contains '"arr": [ "123", "abc", "456", "def" ]'
 assert_output_contains '"more": "ijk789"'
+
 reset_rules
 add_rule 'rule=:%ips:tokenized:, :ipv4% %text:rest%'
 execute '10.20.30.40, 50.60.70.80, 90.100.110.120 are blocked'
 assert_output_contains '"text": "are blocked"'
 assert_output_contains '"ips": [ "10.20.30.40", "50.60.70.80", "90.100.110.120" ]'
+
 reset_rules
 add_rule 'rule=:comma separated list of colon separated list of # separated numbers: %some_nos:tokenized:, :tokenized: \x3a :tokenized:#:number%'
 execute 'comma separated list of colon separated list of # separated numbers: 10, 20 : 30#40#50 : 60#70#80, 90 : 100'

--- a/tests/field_tokenized_recursive.sh
+++ b/tests/field_tokenized_recursive.sh
@@ -1,0 +1,38 @@
+# added 2014-12-08 by singh.janmejay
+# This file is part of the liblognorm project, released under ASL 2.0
+
+source ./exec.sh $0 "tokenized field with recursive field matching tokens"
+
+#recursive field inside tokenized field with default tail field
+add_rule 'rule=:%subnet_addr:ipv4%/%subnet_mask:number%%tail:rest%'
+add_rule 'rule=:%ip_addr:ipv4%%tail:rest%'
+add_rule 'rule=:blocked inbound via: %via_ip:ipv4% from: %addresses:tokenized:, :recursive% to %server_ip:ipv4%'
+execute 'blocked inbound via: 192.168.1.1 from: 1.2.3.4, 5.6.16.0/12, 8.9.10.11, 12.13.14.15, 16.17.18.0/8, 19.20.21.24/3 to 192.168.1.5'
+assert_output_json_eq '{
+"addresses": [
+  {"ip_addr": "1.2.3.4"}, 
+  {"subnet_addr": "5.6.16.0", "subnet_mask": "12"}, 
+  {"ip_addr": "8.9.10.11"}, 
+  {"ip_addr": "12.13.14.15"}, 
+  {"subnet_addr": "16.17.18.0", "subnet_mask": "8"}, 
+  {"subnet_addr": "19.20.21.24", "subnet_mask": "3"}], 
+"server_ip": "192.168.1.5",
+"via_ip": "192.168.1.1"}'
+reset_rules
+
+#recursive field inside tokenized field with default tail field
+reset_rules
+add_rule 'rule=:%subnet_addr:ipv4%/%subnet_mask:number%%remains:rest%'
+add_rule 'rule=:%ip_addr:ipv4%%remains:rest%'
+add_rule 'rule=:blocked inbound via: %via_ip:ipv4% from: %addresses:tokenized:, :recursive:remains% to %server_ip:ipv4%'
+execute 'blocked inbound via: 192.168.1.1 from: 1.2.3.4, 5.6.16.0/12, 8.9.10.11, 12.13.14.15, 16.17.18.0/8, 19.20.21.24/3 to 192.168.1.5'
+assert_output_json_eq '{
+"addresses": [
+  {"ip_addr": "1.2.3.4"}, 
+  {"subnet_addr": "5.6.16.0", "subnet_mask": "12"}, 
+  {"ip_addr": "8.9.10.11"}, 
+  {"ip_addr": "12.13.14.15"}, 
+  {"subnet_addr": "16.17.18.0", "subnet_mask": "8"}, 
+  {"subnet_addr": "19.20.21.24", "subnet_mask": "3"}], 
+"server_ip": "192.168.1.5",
+"via_ip": "192.168.1.1"}'

--- a/tests/field_tokenized_recursive.sh
+++ b/tests/field_tokenized_recursive.sh
@@ -1,6 +1,5 @@
 # added 2014-12-08 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
-
 source ./exec.sh $0 "tokenized field with recursive field matching tokens"
 
 #recursive field inside tokenized field with default tail field
@@ -25,6 +24,24 @@ reset_rules
 add_rule 'rule=:%subnet_addr:ipv4%/%subnet_mask:number%%remains:rest%'
 add_rule 'rule=:%ip_addr:ipv4%%remains:rest%'
 add_rule 'rule=:blocked inbound via: %via_ip:ipv4% from: %addresses:tokenized:, :recursive:remains% to %server_ip:ipv4%'
+execute 'blocked inbound via: 192.168.1.1 from: 1.2.3.4, 5.6.16.0/12, 8.9.10.11, 12.13.14.15, 16.17.18.0/8, 19.20.21.24/3 to 192.168.1.5'
+assert_output_json_eq '{
+"addresses": [
+  {"ip_addr": "1.2.3.4"}, 
+  {"subnet_addr": "5.6.16.0", "subnet_mask": "12"}, 
+  {"ip_addr": "8.9.10.11"}, 
+  {"ip_addr": "12.13.14.15"}, 
+  {"subnet_addr": "16.17.18.0", "subnet_mask": "8"}, 
+  {"subnet_addr": "19.20.21.24", "subnet_mask": "3"}], 
+"server_ip": "192.168.1.5",
+"via_ip": "192.168.1.1"}'
+
+#recursive field inside tokenized field with default tail field
+reset_rules 'net'
+add_rule 'rule=:%subnet_addr:ipv4%/%subnet_mask:number%%remains:rest%' 'net'
+add_rule 'rule=:%ip_addr:ipv4%%remains:rest%' 'net'
+reset_rules
+add_rule 'rule=:blocked inbound via: %via_ip:ipv4% from: %addresses:tokenized:, :descent:'$srcdir'/net.rulebase:remains% to %server_ip:ipv4%'
 execute 'blocked inbound via: 192.168.1.1 from: 1.2.3.4, 5.6.16.0/12, 8.9.10.11, 12.13.14.15, 16.17.18.0/8, 19.20.21.24/3 to 192.168.1.5'
 assert_output_json_eq '{
 "addresses": [

--- a/tests/field_tokenized_with_invalid_ruledef.sh
+++ b/tests/field_tokenized_with_invalid_ruledef.sh
@@ -1,6 +1,5 @@
 # added 2014-11-18 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
-
 source ./exec.sh $0 "tokenized field with invalid rule definition"
 
 add_rule 'rule=:%arr:tokenized%'

--- a/tests/json_eq.c
+++ b/tests/json_eq.c
@@ -1,0 +1,81 @@
+#include "json_compatibility.h"
+#include <stdio.h>
+#include <string.h>
+
+
+typedef struct json_object obj;
+
+static int eq(obj* expected, obj* actual);
+
+static int obj_eq(obj* expected, obj* actual) {
+    struct json_object_iter iter;
+    int eql = 1;
+	json_object_object_foreachC(expected, iter) {
+        obj *actual_val = json_object_object_get(actual, iter.key);
+        eql &= eq(iter.val, actual_val);
+    }
+    return eql;
+}
+
+static int arr_eq(obj* expected, obj* actual) {
+    int eql = 1;
+    int expected_len = json_object_array_length(expected);
+    int actual_len = json_object_array_length(actual);
+    if (expected_len != actual_len) return 0;
+    for (int i = 0; i < expected_len; i++) {
+        obj* exp = json_object_array_get_idx(expected, i);
+        obj* act = json_object_array_get_idx(actual, i);
+        eql &= eq(exp, act);
+    }
+    return eql;
+}
+
+static int str_eq(obj* expected, obj* actual) {
+    const char* exp_str = json_object_to_json_string(expected);
+    const char* act_str = json_object_to_json_string(actual);
+    return strcmp(exp_str, act_str) == 0;
+}
+
+static int eq(obj* expected, obj* actual) {
+    if (expected == NULL && actual == NULL) {
+        return 1;
+    } else if (expected == NULL) {
+        return 0;
+    } else if (actual == NULL) {
+        return 0;
+    }
+    enum json_type expected_type = json_object_get_type(expected);
+    enum json_type actual_type = json_object_get_type(actual);
+    if (expected_type != actual_type) return 0;
+    switch(expected_type) {
+    case json_type_null:
+        return 1;
+    case json_type_boolean:
+        return json_object_get_boolean(expected) == json_object_get_boolean(actual);
+    case json_type_double:
+        return json_object_get_double(expected) == json_object_get_double(actual);
+    case json_type_int:
+        return json_object_get_int64(expected) == json_object_get_int64(actual);
+    case json_type_object:
+        return obj_eq(expected, actual);
+    case json_type_array:
+        return arr_eq(expected, actual);
+    case json_type_string:
+        return str_eq(expected, actual);
+    }
+    return 0;
+}
+
+int main(int argc, char** argv) {
+	if (argc != 3) {
+		fprintf(stderr, "expected and actual json not given, number of args was: %d\n", argc);
+		exit(100);
+	}
+	obj* expected = json_tokener_parse(argv[1]);
+	obj* actual = json_tokener_parse(argv[2]);
+    int result = eq(expected, actual) ? 0 : 1;
+    json_object_put(expected);
+    json_object_put(actual);
+    if (result != 0) { printf("JSONs weren't equal. \n\tExpected: \n\t\t%s\n\tActual: \n\t\t%s\n", argv[1], argv[2]);}
+    return result;
+}


### PR DESCRIPTION
Summary:

- support for 'recursive' field (which calls the ruleset again to match a portion of string)
- support for returning unmatched-suffix fragment using 'tail'(or a configurable name, 'tail' being the default)
- support for type interpretation of field's matched values (via a type called 'interpret'), which supports int, base16-int, double and boolean as of now.
- support for 'descent' field (which is like recursive, but allows calling into a child rulebase). User can specify the file to be used as rulebase, but works similar to recursive.
- a utility(pcons_args function and sisters) for consuming field-declaration arguments, to make consuming optional arguments and generating error messages easier