### PR TITLE
add Alpha field parser

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -115,6 +115,16 @@ up to end of line.
 
     %host:word%
 
+alpha
+####    
+
+One or more alphabetic characters, up to the next whitspace, punctuation,
+decimal digit or control character.
+
+::
+
+    %host:alpha%
+
 char-to
 ####### 
 

--- a/rulebases/sample.rulebase
+++ b/rulebases/sample.rulebase
@@ -66,5 +66,5 @@ rule=tokenized_regex:tokenized regex: %arr:tokenized:; :regex:[^; ]+%
 rule=regex:regex: %token:regex:abc.ef%
 
 # host451
-# generates this fields { basename:"host", hostid:451 }
+# generates  { basename:"host", hostid:451 }
 rule=:%basename:alpha%%hostid:number%

--- a/rulebases/sample.rulebase
+++ b/rulebases/sample.rulebase
@@ -64,3 +64,7 @@ rule=tokenized_regex:tokenized regex: %arr:tokenized:; :regex:[^; ]+%
 
 # regex: abcdef
 rule=regex:regex: %token:regex:abc.ef%
+
+# host451
+# generates this fields { basename:"host", hostid:451 }
+rule=:%basename:alpha%%hostid:number%

--- a/rulebases/syntax.txt
+++ b/rulebases/syntax.txt
@@ -63,6 +63,12 @@ Matches:		One or more characters, up to the next space (\x20), or
 Extra data:		Not used
 Example:		%field_name:word%
 
+Field type:		'alpha'
+Matches:		One or more alphabetic characters, up to the next
+				whitespace, punctuation, decimal digit or ctrl.
+Extra data:		Not used
+Example:		%field_name:alpha%
+
 Field type:		'char-to'
 Matches:		One or more characters, up to the next character given in
 				extra data.

--- a/src/parser.c
+++ b/src/parser.c
@@ -478,6 +478,35 @@ ENDParser
 
 
 /**
+ * Parse a alphabetic word.
+ * A alpha word is composed of characters for which isalpha returns true.
+ * The parser fails if there is no alpha character at all.
+ */
+BEGINParser(Alpha)
+	const char *c;
+	size_t i;
+
+	assert(str != NULL);
+	assert(offs != NULL);
+	assert(parsed != NULL);
+	c = str;
+	i = *offs;
+
+	/* search end of word */
+	while(i < strLen && isalpha(c[i])) 
+		i++;
+
+	if(i == *offs) {
+		goto fail;
+	}
+
+	/* success, persist */
+	*parsed = i - *offs;
+
+ENDParser
+
+
+/**
  * Parse everything up to a specific character.
  * The character must be the only char inside extra data passed to the parser.
  * It is a program error if strlen(ed) != 1. It is considered a format error if

--- a/src/parser.h
+++ b/src/parser.h
@@ -60,6 +60,12 @@ int ln_parseWord(const char *str, size_t strlen, size_t *offs, const ln_fieldLis
 
 
 /** 
+ * Parser for Alphabetic words (no numbers, punct, ctrl, space).
+ */
+int ln_parseAlpha(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);
+
+
+/** 
  * Parse everything up to a specific character.
  */
 int ln_parseCharTo(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);

--- a/src/samp.c
+++ b/src/samp.c
@@ -177,6 +177,8 @@ parseFieldDescr(ln_ctx ctx, struct ln_ptree **subtree, es_str_t *rule,
 		node->parser = ln_parseIPv4;
 	} else if(!es_strconstcmp(*str, "word")) {
 		node->parser = ln_parseWord;
+	} else if(!es_strconstcmp(*str, "alpha")) {
+		node->parser = ln_parseAlpha;
 	} else if(!es_strconstcmp(*str, "rest")) {
 		node->parser = ln_parseRest;
 	} else if(!es_strconstcmp(*str, "quoted-string")) {


### PR DESCRIPTION
parse a sequence of strictly alphabetic characters.
allows to parse sequences like 'host451' with a rule like %base:alpha%%index:number%