### PR TITLE
Adding op-quoted-string, to-string, and bugfix on docs.

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -115,6 +115,17 @@ up to end of line.
 
     %host:word%
 
+string-to
+######### 
+
+One or more characters, up to the next string given in
+extra data.
+
+::
+
+    %field_name:char-to:,%
+    %field_name:char-to:\x25%
+
 char-to
 ####### 
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -159,6 +159,18 @@ Quote marks are stripped from the match.
 
     %field_name:quoted-string%
 
+op-quoted-string
+################   
+
+
+Zero or more characters, possibly surrounded by double quote marks.
+If the first character is a quote mark, operates like quoted-string. Otherwise, operates like "word"
+Quote marks are stripped from the match.
+
+::
+
+    %field_name:quoted-string%
+
 date-iso
 ########    
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -123,8 +123,8 @@ extra data.
 
 ::
 
-    %field_name:char-to:,%
-    %field_name:char-to:\x25%
+    %field_name:string-to:Auth%
+    %field_name:string-to:Auth\x25%
 
 char-to
 ####### 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -127,7 +127,7 @@ extra data.
     %field_name:string-to:Auth\x25%
 
 alpha
-####    
+#####   
 
 One or more alphabetic characters, up to the next whitspace, punctuation,
 decimal digit or control character.

--- a/src/parser.c
+++ b/src/parser.c
@@ -478,6 +478,54 @@ ENDParser
 
 
 /**
+ * Parse everything up to a specific string.
+ * swisskid, 2015-01-21
+ */
+BEGINParser(StringTo)
+	const char *c;
+	const char *toFind;
+	size_t i, j, k, m;
+	int chkstr;
+
+	assert(str != NULL);
+	assert(offs != NULL);
+	assert(parsed != NULL);
+	assert(ed != NULL);
+	k = es_strlen(ed) - 1;
+	toFind = es_str2cstr(ed, NULL);
+	c = str;
+	i = *offs;
+	chkstr = 0;
+
+	/* Total hunt for letter */
+	while(chkstr == 0 && i < strLen ) {
+	    i++;
+	    if(c[i] == toFind[0]) {
+		/* Found the first letter, now find the rest of the string */
+		j = 0;
+		m = i;
+		while(m < strLen && j < k ) {
+		    m++;
+		    j++;
+		    if(c[m] != toFind[j])
+			break;
+		    if (j == k) 
+			chkstr = 1;
+		}
+	    }
+	}
+	if(i == *offs || i == strLen || c[i] != toFind[0]) {
+		r = LN_WRONGPARSER;
+		goto fail;
+	} 
+
+	/* success, persist */
+	*parsed = i - *offs;
+
+ENDParser
+
+
+/**
  * Parse everything up to a specific character.
  * The character must be the only char inside extra data passed to the parser.
  * It is a program error if strlen(ed) != 1. It is considered a format error if

--- a/src/parser.h
+++ b/src/parser.h
@@ -60,6 +60,11 @@ int ln_parseWord(const char *str, size_t strlen, size_t *offs, const ln_fieldLis
 
 
 /** 
+ * Parse everything up to a specific string.
+ */
+int ln_parseStringTo(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);
+
+/** 
  * Parse everything up to a specific character.
  */
 int ln_parseCharTo(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);

--- a/src/parser.h
+++ b/src/parser.h
@@ -75,6 +75,10 @@ int ln_parseCharSeparated(const char *str, size_t strlen, size_t *offs, const ln
  */
 int ln_parseRest(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);
 
+/** 
+ * Parse an optionally quoted string.
+ */
+int ln_parseOpQuotedString(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);
 
 /** 
  * Parse a quoted string.

--- a/src/samp.c
+++ b/src/samp.c
@@ -179,6 +179,8 @@ parseFieldDescr(ln_ctx ctx, struct ln_ptree **subtree, es_str_t *rule,
 		node->parser = ln_parseWord;
 	} else if(!es_strconstcmp(*str, "rest")) {
 		node->parser = ln_parseRest;
+	} else if(!es_strconstcmp(*str, "op-quoted-string")) {
+		node->parser = ln_parseOpQuotedString;
 	} else if(!es_strconstcmp(*str, "quoted-string")) {
 		node->parser = ln_parseQuotedString;
 	} else if(!es_strconstcmp(*str, "date-iso")) {

--- a/src/samp.c
+++ b/src/samp.c
@@ -192,6 +192,9 @@ parseFieldDescr(ln_ctx ctx, struct ln_ptree **subtree, es_str_t *rule,
 	} else if(!es_strconstcmp(*str, "iptables")) {
 		node->parser = NULL;
 		node->isIPTables = 1;
+	} else if(!es_strconstcmp(*str, "string-to")) {
+		// TODO: check extra data!!!! (very important)
+		node->parser = ln_parseStringTo;
 	} else if(!es_strconstcmp(*str, "char-to")) {
 		// TODO: check extra data!!!! (very important)
 		node->parser = ln_parseCharTo;


### PR DESCRIPTION
op-quoted-string:
Basically just making an additional one like quoted string that does a quoted string if the first character is ", and does word matching otherwise.
to-string:
Matching up to a string. Copied the char-to function, then modified to check for the rest of the string after the first character matches. I believe this doesn't work with hex characters (so no \x20 and such) but it removes the need for using the regex function a good amount of the time
Bugfix:
Alpha (in the docs) didn't have the correct number of "#" under it. Fixed.