### PR TITLE
Changed double comparison in json eq. Fixed unit test of interpret

### DIFF
--- a/tests/field_interpret.sh
+++ b/tests/field_interpret.sh
@@ -32,8 +32,8 @@ assert_output_json_eq '{"shard": 63, "record_count": 50000, "latency_percentile"
 
 reset_rules
 add_rule 'rule=:%latency_percentile:interpret:float:char-to:\x25%\x25ile latency is %latency:interpret:float:word%'
-execute '98%ile latency is 1.999123'
-assert_output_json_eq '{"latency_percentile": 98.0, "latency": 1.999123}'
+execute '98.1%ile latency is 1.999123'
+assert_output_json_eq '{"latency_percentile": 98.1, "latency": 1.999123}'
 
 reset_rules
 add_rule 'rule=:%latency_percentile:interpret:float:number%'

--- a/tests/json_eq.c
+++ b/tests/json_eq.c
@@ -1,6 +1,7 @@
 #include "json_compatibility.h"
 #include <stdio.h>
 #include <string.h>
+#include <math.h>
 
 
 typedef struct json_object obj;
@@ -53,7 +54,7 @@ static int eq(obj* expected, obj* actual) {
     case json_type_boolean:
         return json_object_get_boolean(expected) == json_object_get_boolean(actual);
     case json_type_double:
-        return json_object_get_double(expected) == json_object_get_double(actual);
+        return (fabs(json_object_get_double(expected) - json_object_get_double(actual)) < 0.001);
     case json_type_int:
         return json_object_get_int64(expected) == json_object_get_int64(actual);
     case json_type_object:


### PR DESCRIPTION
json-c-0.12 has changed implementation of json_object_double_to_json_string. This was causing interpret unit failure.
Also change equality test for double from direct comparison to standard floating point comparison by checking difference to a error limit.