### PR TITLE
Support for float, suffixed-fields and a bug-fix to tokenized

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: c
 
 before_install:
-- travis_retry sudo apt-get install -qq python-sphinx libpcre3-dev libpcre3-dbg valgrind
+- travis_retry sudo apt-get install -qq libpcre3-dev libpcre3-dbg valgrind python-pip
+- travis_retry sudo pip install sphinx
 - travis_retry sudo add-apt-repository ppa:adiscon/v8-devel -y
 - travis_retry sudo apt-get update -qq
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: c
 
 before_install:
+- travis_retry sudo apt-get update -qq
 - travis_retry sudo apt-get install -qq libpcre3-dev libpcre3-dbg valgrind python-pip
 - travis_retry sudo pip install sphinx
 - travis_retry sudo add-apt-repository ppa:adiscon/v8-devel -y

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 
 before_install:
-- travis_retry sudo apt-get install -qq python-sphinx
+- travis_retry sudo apt-get install -qq python-sphinx libpcre3-dev libpcre3-dbg valgrind
 - travis_retry sudo add-apt-repository ppa:adiscon/v8-devel -y
 - travis_retry sudo apt-get update -qq
 
@@ -10,5 +10,5 @@ install:
 
 script:
   - autoreconf --force --verbose --install
-  - ./configure --prefix=/opt/liblognorm --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu --mandir=/usr/share/man --infodir=/usr/share/info --datadir=/usr/share --sysconfdir=/etc --localstatedir=/var/lib --disable-dependency-tracking --disable-silent-rules --libdir=/usr/lib64 --enable-debug --enable-testbench --disable-valgrind --enable-docs
+  - ./configure --prefix=/opt/liblognorm --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu --mandir=/usr/share/man --infodir=/usr/share/info --datadir=/usr/share --sysconfdir=/etc --localstatedir=/var/lib --disable-dependency-tracking --disable-silent-rules --libdir=/usr/lib64 --enable-debug --enable-testbench --enable-valgrind --enable-regexp --enable-docs
   - make && make dist && make check && sudo make install

--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,7 @@ AC_CHECK_FUNCS(json_object_get_string_len,,)
 AC_CHECK_TYPE(json_bool,,,)
 AC_CHECK_FUNCS(json_object_get_int64,,)
 AC_CHECK_FUNCS(json_object_new_int64,,)
+AC_CHECK_MEMBERS([json_object_iter.key],,,[#include <json.h>])
 LIBS="$LIBS_BEFORE"
 CFLAGS="$CFLAGS_BEFORE"
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -529,6 +529,86 @@ Here is a table of supported interpretation:
 |           |                      | "FALSE"       | false          |
 +-----------+----------------------+---------------+----------------+
 
+suffixed
+########
+
+Value that can be matched by any available field-type but also has one
+of many suffixes which must be captured alongwith, for the captured data
+to be used sensibly.
+
+The invocation below will capture units alongwith quantity.
+
+::
+
+    %free_space:suffixed:,:b,kb,mb,gb:number%
+
+It takes 3 arguments. First is delimiter for possible-suffixes enumeration,
+second is the enumeration itself (separated by declared delimiter) and third
+captures type to be used to parse the value itself.
+
+It returns an object with key "value" which holds the parsed value and
+a key "suffix" which captures which one of the provided suffixes was found
+after it.
+
+Here is an example that parses suffixed values:
+
+::
+
+    rule=:reclaimed %eden_reclaimed:suffixed:,:b,kb,mb,gb:number% from eden
+
+Given text "reclaimed 115mb from eden" the 
+above rule would produce:
+
+.. code-block:: json
+
+  {
+    "eden_reclaimed":
+      {
+        "value": "115", 
+        "suffix": "mb"
+      }
+  }
+
+It can be used with interpret to actually get numeric values, and field-type
+named_suffix field can be used if the default keys used are not sensible.
+
+named_suffixed
+##############
+
+Works exactly like suffixed, but allows user to specify key-litterals for "value"
+and "suffix" fields.
+
+The invocation below will capture units alongwith quantity.
+
+::
+
+    %free_space:named_suffixed:mem:unit:,:b,kb,mb,gb:number%
+
+It takes 5 arguments. First is the litteral to be used as key for parsed-value,
+second is key-litteral for suffix, and list three which exactly match field-type
+suffixed. Third is delimiter for possible-suffixes enumeration,
+fourth is the enumeration itself (separated by declared delimiter)
+and fifth captures type to be used to parse the value itself.
+
+Here is an example that parses suffixed values:
+
+::
+
+    rule=:reclaimed %eden_reclaimed:named_suffixed:mem:unit:,:b,kb,mb,gb:number% from eden
+
+Given text "reclaimed 115mb from eden" the 
+above rule would produce:
+
+.. code-block:: json
+
+  {
+    "eden_reclaimed":
+      {
+        "mem": "115", 
+        "unit": "mb"
+      }
+  }
+
 
 iptables
 ########    

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -105,6 +105,15 @@ One or more decimal digits.
 
     %port:number%
 
+float
+#####
+
+A floating-pt number represented in non-scientific form.
+
+::
+
+    %pause_time:float%
+
 word
 ####    
 

--- a/src/json_compatibility.c
+++ b/src/json_compatibility.c
@@ -17,6 +17,7 @@ int json_object_object_get_ex(struct json_object* obj,
 
 #ifndef HAVE_JSON_OBJECT_GET_STRING_LEN
 int json_object_get_string_len(struct json_object *obj) {
+	if (obj == NULL) return 0;
 	const char* str = json_object_get_string(obj);
 	return strlen(str);
 }

--- a/src/json_compatibility.c
+++ b/src/json_compatibility.c
@@ -6,8 +6,12 @@
 int json_object_object_get_ex(struct json_object* obj,
 							  const char *key,
 							  struct json_object **value) {
-	*value = json_object_object_get(obj, key);
-	return *value != NULL;
+	json_object* tmp = NULL;
+	tmp = json_object_object_get(obj, key);
+	if (value != NULL) {
+		*value = tmp;
+	}
+	return tmp != NULL;
 }
 #endif
 

--- a/src/json_compatibility.h
+++ b/src/json_compatibility.h
@@ -23,6 +23,15 @@ int64_t json_object_get_int64(struct json_object *jso);
 struct json_object* json_object_new_int64(int64_t i);
 #endif
 
+#ifndef HAVE_JSON_OBJECT_ITER_KEY
+struct json_object_iter
+{
+	char *key;
+	struct json_object *val;
+	struct lh_entry *entry;
+};
+#endif
+
 #ifndef json_object_object_foreachC
 #define json_object_object_foreachC(obj,iter)							\
 	for(iter.entry = json_object_get_object(obj)->head; (iter.entry ? (iter.key = (char*)iter.entry->k, iter.val = (struct json_object*)iter.entry->v, iter.entry) : 0); iter.entry = iter.entry->next)

--- a/src/json_compatibility.h
+++ b/src/json_compatibility.h
@@ -22,3 +22,8 @@ int64_t json_object_get_int64(struct json_object *jso);
 #ifndef HAVE_JSON_OBJECT_NEW_INT64
 struct json_object* json_object_new_int64(int64_t i);
 #endif
+
+#ifndef json_object_object_foreachC
+#define json_object_object_foreachC(obj,iter)							\
+	for(iter.entry = json_object_get_object(obj)->head; (iter.entry ? (iter.key = (char*)iter.entry->k, iter.val = (struct json_object*)iter.entry->v, iter.entry) : 0); iter.entry = iter.entry->next)
+#endif

--- a/src/lognormalizer.c
+++ b/src/lognormalizer.c
@@ -32,6 +32,7 @@
  *
  * A copy of the LGPL v2.1 can be found in the file "COPYING" in this distribution.
  */
+#include "config.h"
 #include <stdio.h>
 #include <string.h>
 #include <getopt.h>

--- a/src/parser.c
+++ b/src/parser.c
@@ -1046,6 +1046,7 @@ void* tokenized_parser_data_constructor(ln_fieldList_t *node, ln_ctx ctx) {
 	pcons_unescape_arg(args, 0);
 	CHKN(tok = pcons_arg(args, 0, NULL));
 	CHKN(pData->tok_str = es_newStrFromCStr(tok, strlen(tok)));
+	es_unescapeStr(pData->tok_str);
 	CHKN(field_descr = pcons_arg(args, 1, NULL));
 	const int field_descr_len = strlen(field_descr);
 	pData->free_ctx = 1;
@@ -1469,6 +1470,7 @@ static struct suffixed_parser_data_s* _suffixed_parser_data_constructor(ln_field
 	CHKN(tokenizer = pcons_arg(args, 0, NULL));
 
 	CHKN(uncopied_suffixes_str = pcons_arg(args, 1, NULL));
+	pcons_unescape_arg(args, 1);
 	CHKN(suffixes_str = pcons_arg_copy(args, 1, NULL));
 
 	tok_input = suffixes_str;

--- a/src/parser.c
+++ b/src/parser.c
@@ -526,6 +526,40 @@ BEGINParser(Number)
 
 ENDParser
 
+/**
+ * Parse a Real-number in floating-pt form.
+ */
+BEGINParser(Float)
+const char *c;
+size_t i;
+
+assert(str != NULL);
+assert(offs != NULL);
+assert(parsed != NULL);
+c = str;
+
+int seen_point = 0;
+
+i = *offs;
+
+if (c[i] == '-') i++; 
+
+for (; i < strLen; i++) {
+	if (c[i] == '.') {
+		if (seen_point != 0) break;
+		seen_point = 1;
+	} else if (! isdigit(c[i])) {
+		break;
+	} 
+}
+if (i == *offs)
+	goto fail;
+	
+/* success, persist */
+*parsed = i - *offs;
+
+ENDParser
+
 
 /**
  * Parse a word.

--- a/src/parser.c
+++ b/src/parser.c
@@ -91,6 +91,17 @@ int ln_parse##ParserName(const char *str, size_t strLen, size_t *offs,       \
 	__attribute__((unused)) es_str_t *ed = node->data;  \
 	*parsed = 0;
 
+#define FAILParser \
+	goto done; /* suppress warnings */ \
+done: \
+	r = 0; \
+	goto fail; /* suppress warnings */ \
+fail: 
+
+#define ENDFailParser \
+	return r; \
+}
+
 #define ENDParser \
 	goto done; /* suppress warnings */ \
 done: \
@@ -1357,6 +1368,209 @@ void interpret_parser_data_destructor(void** dataPtr) {
 		*dataPtr = NULL;
 	}
 };
+
+/**
+ * Parse suffixed char-sequence, where suffix is one of many possible suffixes.
+ */
+struct suffixed_parser_data_s {
+	int nsuffix;
+	int *suffix_offsets;
+    int *suffix_lengths;
+	char* suffixes_str;
+	ln_ctx ctx;
+	char* value_field_name;
+	char* suffix_field_name;
+};
+
+BEGINParser(Suffixed) {
+	assert(str != NULL);
+	assert(offs != NULL);
+	assert(parsed != NULL);
+	json_object *unparsed = NULL;
+	json_object *parsed_raw = NULL;
+	json_object *parsed_value = NULL;
+    json_object *result = NULL;
+    json_object *suffix = NULL;
+
+	struct suffixed_parser_data_s *pData = (struct suffixed_parser_data_s*) node->parser_data;
+
+	if (pData != NULL) {
+		int remaining_len = strLen - *offs;
+		const char *remaining_str = str + *offs;
+		int i;
+
+		CHKN(parsed_raw = json_object_new_object());
+
+		ln_normalize(pData->ctx, remaining_str, remaining_len, &parsed_raw);
+
+		if (json_object_object_get_ex(parsed_raw, UNPARSED_DATA_KEY, NULL)) {
+			*parsed = 0;
+		} else {
+			json_object_object_get_ex(parsed_raw, DEFAULT_MATCHED_FIELD_NAME, &parsed_value);
+			json_object_object_get_ex(parsed_raw, DEFAULT_REMAINING_FIELD_NAME, &unparsed);
+            const char* unparsed_frag = json_object_get_string(unparsed);
+			for(i = 0; i < pData->nsuffix; i++) {
+                const char* possible_suffix = pData->suffixes_str + pData->suffix_offsets[i];
+				int len = pData->suffix_lengths[i];
+				if (strncmp(possible_suffix, unparsed_frag, len) == 0) {
+                    CHKN(result = json_object_new_object());
+                    CHKN(suffix = json_object_new_string(possible_suffix));
+					json_object_get(parsed_value);
+                    json_object_object_add(result, pData->value_field_name, parsed_value);
+                    json_object_object_add(result, pData->suffix_field_name, suffix);
+					*parsed = strLen - *offs - json_object_get_string_len(unparsed) + len;
+                    break;
+                }
+			}
+            if (result != NULL) {
+                *value = result;
+            }
+		}
+	}
+FAILParser
+	if (r != 0) {
+		if (result != NULL) json_object_put(result);
+	}
+	if (parsed_raw != NULL) json_object_put(parsed_raw);
+} ENDFailParser
+
+static struct suffixed_parser_data_s* _suffixed_parser_data_constructor(ln_fieldList_t *node,
+																 ln_ctx ctx,
+																 es_str_t* raw_args,
+																 const char* value_field,
+																 const char* suffix_field) {
+	int r = LN_BADCONFIG;
+	pcons_args_t* args = NULL;
+	char* name = NULL;
+	struct suffixed_parser_data_s *pData = NULL;
+	const char *escaped_tokenizer = NULL;
+	const char *uncopied_suffixes_str = NULL;
+	const char *tokenizer = NULL;
+	char *suffixes_str = NULL;
+	const char *field_type = NULL;
+
+	char *tok_saveptr = NULL;
+	char *tok_input = NULL;
+	int i = 0;
+	char *tok = NULL;
+
+	CHKN(name = es_str2cstr(node->name, NULL));
+
+	CHKN(pData = calloc(1, sizeof(struct suffixed_parser_data_s)));
+
+	if (value_field == NULL) value_field = "value";
+	if (suffix_field == NULL) suffix_field = "suffix";
+	pData->value_field_name = strdup(value_field);
+	pData->suffix_field_name = strdup(suffix_field);
+
+	CHKN(args = pcons_args(raw_args, 3));
+	CHKN(escaped_tokenizer = pcons_arg(args, 0, NULL));
+	pcons_unescape_arg(args, 0);
+	CHKN(tokenizer = pcons_arg(args, 0, NULL));
+
+	CHKN(uncopied_suffixes_str = pcons_arg(args, 1, NULL));
+	CHKN(suffixes_str = pcons_arg_copy(args, 1, NULL));
+
+	tok_input = suffixes_str;
+	while (strtok_r(tok_input, tokenizer, &tok_saveptr) != NULL) {
+		tok_input = NULL;
+		pData->nsuffix++;
+	}
+
+	CHKN(pData->suffix_offsets = calloc(pData->nsuffix, sizeof(int)));
+    CHKN(pData->suffix_lengths = calloc(pData->nsuffix, sizeof(int)));
+	CHKN(pData->suffixes_str = pcons_arg_copy(args, 1, NULL));
+
+	tok_input = pData->suffixes_str;
+	while ((tok = strtok_r(tok_input, tokenizer, &tok_saveptr)) != NULL) {
+		tok_input = NULL;
+		pData->suffix_offsets[i] = tok - pData->suffixes_str;
+        pData->suffix_lengths[i++] = strlen(tok);
+	}
+
+	CHKN(field_type = pcons_arg(args, 2, NULL));
+	CHKN(pData->ctx = generate_context_with_field_as_prefix(ctx, field_type, strlen(field_type)));
+	
+	r = 0;
+done:
+	if (r != 0) {
+		if (name == NULL) ln_dbgprintf(ctx, "couldn't allocate memory suffixed-field name");
+		else if (pData == NULL) ln_dbgprintf(ctx, "couldn't allocate memory for parser-data for field: %s", name);
+		else if (pData->value_field_name == NULL) ln_dbgprintf(ctx, "couldn't allocate memory for value-field's name for field: %s", name);
+		else if (pData->suffix_field_name == NULL) ln_dbgprintf(ctx, "couldn't allocate memory for suffix-field's name for field: %s", name);
+		else if (args == NULL) ln_dbgprintf(ctx, "couldn't allocate memory for argument-parsing for field: %s", name);
+		else if (escaped_tokenizer == NULL) ln_dbgprintf(ctx, "suffix token-string missing for field: '%s'", name);
+		else if (tokenizer == NULL) ln_dbgprintf(ctx, "couldn't allocate memory for unescaping token-string for field: '%s'", name);
+		else if (uncopied_suffixes_str == NULL)  ln_dbgprintf(ctx, "suffix-list missing for field: '%s'", name);
+		else if (suffixes_str == NULL)  ln_dbgprintf(ctx, "couldn't allocate memory for suffix-list for field: '%s'", name);
+		else if (pData->suffix_offsets == NULL)
+			ln_dbgprintf(ctx, "couldn't allocate memory for suffix-list element references for field: '%s'", name);
+		else if (pData->suffix_lengths == NULL)
+			ln_dbgprintf(ctx, "couldn't allocate memory for suffix-list element lengths for field: '%s'", name);
+		else if (pData->suffixes_str == NULL)
+			ln_dbgprintf(ctx, "couldn't allocate memory for suffix-list for field: '%s'", name);
+		else if (field_type == NULL)  ln_dbgprintf(ctx, "field-type declaration missing for field: '%s'", name);
+		else if (pData->ctx == NULL)  ln_dbgprintf(ctx, "couldn't allocate memory for normalizer-context for field: '%s'", name);
+		suffixed_parser_data_destructor((void**)&pData);
+	}
+	free_pcons_args(&args);
+	if (suffixes_str != NULL) free(suffixes_str);
+	if (name != NULL) free(name);
+	return pData;
+}
+
+void* suffixed_parser_data_constructor(ln_fieldList_t *node, ln_ctx ctx) {
+	return _suffixed_parser_data_constructor(node, ctx, node->raw_data, NULL, NULL);
+}
+
+void* named_suffixed_parser_data_constructor(ln_fieldList_t *node, ln_ctx ctx) {
+	int r = LN_BADCONFIG;
+	pcons_args_t* args = NULL;
+	char* name = NULL;
+	const char* value_field_name = NULL;
+	const char* suffix_field_name = NULL;
+	const char* remaining_args = NULL;
+	es_str_t* unnamed_suffix_args = NULL;
+	struct suffixed_parser_data_s* pData = NULL;
+	CHKN(name = es_str2cstr(node->name, NULL));
+	CHKN(args = pcons_args(node->raw_data, 3));
+	CHKN(value_field_name = pcons_arg(args, 0, NULL));
+	CHKN(suffix_field_name = pcons_arg(args, 1, NULL));
+	CHKN(remaining_args = pcons_arg(args, 2, NULL));
+	CHKN(unnamed_suffix_args = es_newStrFromCStr(remaining_args, strlen(remaining_args)));
+	
+	CHKN(pData = _suffixed_parser_data_constructor(node, ctx, unnamed_suffix_args, value_field_name, suffix_field_name));
+	r = 0;
+done:
+	if (r != 0) {
+		if (name == NULL) ln_dbgprintf(ctx, "couldn't allocate memory named_suffixed-field name");
+		else if (args == NULL) ln_dbgprintf(ctx, "couldn't allocate memory for argument-parsing for field: %s", name);
+		else if (value_field_name == NULL) ln_dbgprintf(ctx, "key-name for value not provided for field: %s", name);
+		else if (suffix_field_name == NULL) ln_dbgprintf(ctx, "key-name for suffix not provided for field: %s", name);
+		else if (unnamed_suffix_args == NULL) ln_dbgprintf(ctx, "couldn't allocate memory for unnamed-suffix-field args for field: %s", name);
+		else if (pData == NULL) ln_dbgprintf(ctx, "couldn't create parser-data for field: %s", name);
+		suffixed_parser_data_destructor((void**)&pData);
+	}
+	if (unnamed_suffix_args != NULL) free(unnamed_suffix_args);
+	if (args != NULL) free_pcons_args(&args);
+	if (name != NULL) free(name);
+	return pData;
+}
+
+
+void suffixed_parser_data_destructor(void** dataPtr) {
+	if ((*dataPtr) != NULL) {
+		struct suffixed_parser_data_s *pData = (struct suffixed_parser_data_s*) *dataPtr;
+		if (pData->suffixes_str != NULL) free(pData->suffixes_str);
+		if (pData->suffix_offsets != NULL) free(pData->suffix_offsets);
+		if (pData->suffix_lengths != NULL) free(pData->suffix_lengths);
+		if (pData->value_field_name != NULL) free(pData->value_field_name);
+		if (pData->suffix_field_name != NULL) free(pData->suffix_field_name);
+		if (pData->ctx != NULL)	ln_exitCtx(pData->ctx);
+		free(pData);
+		*dataPtr = NULL;
+	}
+}
 
 /**
  * Just get everything till the end of string.

--- a/src/parser.h
+++ b/src/parser.h
@@ -56,6 +56,10 @@ int ln_parseRFC3164Date(const char *str, size_t strlen, size_t *offs, const ln_f
  */
 int ln_parseNumber(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);
 
+/** 
+ * Parser for real-number in floating-pt representation
+ */
+int ln_parseFloat(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);
 
 /** 
  * Parser for Words (SP-terminated strings).

--- a/src/parser.h
+++ b/src/parser.h
@@ -161,4 +161,13 @@ int ln_parseInterpret(const char *str, size_t strlen, size_t *offs, const ln_fie
 void* interpret_parser_data_constructor(ln_fieldList_t *node, ln_ctx ctx);
 void interpret_parser_data_destructor(void** dataPtr);
 
+/** 
+ * Parse a suffixed field
+ */
+int ln_parseSuffixed(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);
+
+void* suffixed_parser_data_constructor(ln_fieldList_t *node, ln_ctx ctx);
+void* named_suffixed_parser_data_constructor(ln_fieldList_t *node, ln_ctx ctx);
+void suffixed_parser_data_destructor(void** dataPtr);
+
 #endif /* #ifndef LIBLOGNORM_PARSER_H_INCLUDED */

--- a/src/samp.c
+++ b/src/samp.c
@@ -239,6 +239,14 @@ ln_parseFieldDescr(ln_ctx ctx, es_str_t *rule, es_size_t *bufOffs, es_str_t **st
         node->parser = ln_parseInterpret;
         constructor_fn = interpret_parser_data_constructor;
         node->parser_data_destructor = interpret_parser_data_destructor;
+    } else if (!es_strconstcmp(*str, "suffixed")) {
+        node->parser = ln_parseSuffixed;
+        constructor_fn = suffixed_parser_data_constructor;
+        node->parser_data_destructor = suffixed_parser_data_destructor;
+    } else if (!es_strconstcmp(*str, "named_suffixed")) {
+        node->parser = ln_parseSuffixed;
+        constructor_fn = named_suffixed_parser_data_constructor;
+        node->parser_data_destructor = suffixed_parser_data_destructor;
     } else {
 		cstr = es_str2cstr(*str, NULL);
 		ln_dbgprintf(ctx, "ERROR: invalid field type '%s'", cstr);

--- a/src/samp.c
+++ b/src/samp.c
@@ -183,6 +183,8 @@ ln_parseFieldDescr(ln_ctx ctx, es_str_t *rule, es_size_t *bufOffs, es_str_t **st
 		node->parser = ln_parseRFC5424Date;
 	} else if(!es_strconstcmp(*str, "number")) {
 		node->parser = ln_parseNumber;
+	} else if(!es_strconstcmp(*str, "float")) {
+		node->parser = ln_parseFloat;
 	} else if(!es_strconstcmp(*str, "ipv4")) {
 		node->parser = ln_parseIPv4;
 	} else if(!es_strconstcmp(*str, "word")) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,6 @@
 check_PROGRAMS = json_eq user_test
-json_eq_SOURCES = json_eq.c $(top_srcdir)/src/json_compatibility.c
+json_eq_self_sources = json_eq.c
+json_eq_SOURCES = $(json_eq_self_sources) $(top_srcdir)/src/json_compatibility.c
 json_eq_CPPFLAGS =  $(JSON_C_CFLAGS) -I$(top_srcdir)/src
 json_eq_LDADD = $(JSON_C_LIBS)
 json_eq_LDFLAGS = -no-install
@@ -19,10 +20,12 @@ TESTS = \
 	field_interpret_with_invalid_ruledef.sh \
 	field_descent.sh \
 	field_descent_with_invalid_ruledef.sh \
-        field_float.sh
+        field_float.sh \
+	field_float_with_invalid_ruledef.sh \
+	field_suffixed.sh \
+	field_suffixed_with_invalid_ruledef.sh
 
-if ENABLE_REGEXP
-TESTS +=  \
+REGEXP_TESTS = \
 	field_regex_default_group_parse_and_return.sh \
 	field_regex_invalid_args.sh \
 	field_regex_with_consume_group.sh \
@@ -30,19 +33,13 @@ TESTS +=  \
 	field_regex_with_negation.sh \
 	field_tokenized_with_regex.sh \
 	field_regex_while_regex_support_is_disabled.sh
+
+EXTRA_DIST = exec.sh \
+	$(TESTS) \
+	$(REGEXP_TESTS) \
+	$(json_eq_self_sources) \
+	$(user_test_SOURCES)
+
+if ENABLE_REGEXP
+TESTS += $(REGEXP_TESTS)
 endif
-
-EXTRA_DIST = exec.sh
-
-# tests
-EXTRA_DIST += \
-	field_tokenized.sh \
-	field_tokenized_with_invalid_ruledef.sh \
-	field_regex_default_group_parse_and_return.sh \
-	field_regex_invalid_args.sh \
-	field_regex_with_consume_group.sh \
-	field_regex_with_consume_group_and_return_group.sh \
-	field_regex_with_negation.sh \
-	field_tokenized_with_regex.sh \
-	field_regex_while_regex_support_is_disabled.sh \
-	field_float.sh

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -18,7 +18,8 @@ TESTS = \
 	field_interpret.sh \
 	field_interpret_with_invalid_ruledef.sh \
 	field_descent.sh \
-	field_descent_with_invalid_ruledef.sh
+	field_descent_with_invalid_ruledef.sh \
+        field_float.sh
 
 if ENABLE_REGEXP
 TESTS +=  \
@@ -35,7 +36,7 @@ EXTRA_DIST = exec.sh
 
 # tests
 EXTRA_DIST += \
-  field_tokenized.sh \
+	field_tokenized.sh \
 	field_tokenized_with_invalid_ruledef.sh \
 	field_regex_default_group_parse_and_return.sh \
 	field_regex_invalid_args.sh \
@@ -43,4 +44,5 @@ EXTRA_DIST += \
 	field_regex_with_consume_group_and_return_group.sh \
 	field_regex_with_negation.sh \
 	field_tokenized_with_regex.sh \
-	field_regex_while_regex_support_is_disabled.sh
+	field_regex_while_regex_support_is_disabled.sh \
+	field_float.sh

--- a/tests/field_float.sh
+++ b/tests/field_float.sh
@@ -1,0 +1,12 @@
+# added 2015-02-25 by singh.janmejay
+# This file is part of the liblognorm project, released under ASL 2.0
+source ./exec.sh $0 "float field"
+add_rule 'rule=:here is a number %num:float% in floating pt form'
+execute 'here is a number 15.9 in floating pt form'
+assert_output_json_eq '{"num": "15.9"}'
+
+reset_rules
+
+add_rule 'rule=:here is a negative number %num:float% for you'
+execute 'here is a negative number -4.2 for you'
+assert_output_json_eq '{"num": "-4.2"}'

--- a/tests/field_float.sh
+++ b/tests/field_float.sh
@@ -10,3 +10,9 @@ reset_rules
 add_rule 'rule=:here is a negative number %num:float% for you'
 execute 'here is a negative number -4.2 for you'
 assert_output_json_eq '{"num": "-4.2"}'
+
+reset_rules
+
+add_rule 'rule=:here is another real number %real_no:float%.'
+execute 'here is another real number 2.71.'
+assert_output_json_eq '{"real_no": "2.71"}'

--- a/tests/field_float_with_invalid_ruledef.sh
+++ b/tests/field_float_with_invalid_ruledef.sh
@@ -1,0 +1,7 @@
+# added 2015-02-26 by singh.janmejay
+# This file is part of the liblognorm project, released under ASL 2.0
+source ./exec.sh $0 "float with invalid field-declaration"
+
+add_rule 'rule=:%no:flo% foo'
+execute '10.0 foo'
+assert_output_json_eq '{ "originalmsg": "10.0 foo", "unparsed-data": "10.0 foo" }'

--- a/tests/field_interpret.sh
+++ b/tests/field_interpret.sh
@@ -44,3 +44,7 @@ add_rule 'rule=:%latency_percentile:interpret:boolean:number%'
 execute 'foo'
 assert_output_json_eq '{ "originalmsg": "foo", "unparsed-data": "foo" }'
 
+reset_rules
+add_rule 'rule=:gc pause: %pause_time:interpret:float:float%ms'
+execute 'gc pause: 12.3ms'
+assert_output_json_eq '{"pause_time": 12.3}'

--- a/tests/field_suffixed.sh
+++ b/tests/field_suffixed.sh
@@ -1,0 +1,13 @@
+# added 2015-02-25 by singh.janmejay
+# This file is part of the liblognorm project, released under ASL 2.0
+source ./exec.sh $0 "field with one of many possible suffixes"
+
+add_rule 'rule=:gc reclaimed %eden_free:suffixed:,:b,kb,mb,gb:number% eden [surviver: %surviver_used:suffixed:;:kb;mb;gb;b:number%/%surviver_size:suffixed:|:b|kb|mb|gb:float%]'
+execute 'gc reclaimed 559mb eden [surviver: 95b/30.2mb]'
+assert_output_json_eq '{"eden_free": {"value": "559", "suffix":"mb"}, "surviver_used": {"value": "95", "suffix": "b"}, "surviver_size": {"value": "30.2", "suffix": "mb"}}'
+
+reset_rules
+
+add_rule 'rule=:gc reclaimed %eden_free:named_suffixed:size:unit:,:b,kb,mb,gb:number% eden [surviver: %surviver_used:named_suffixed:sz:u:;:kb;mb;gb;b:number%/%surviver_size:suffixed:|:b|kb|mb|gb:float%]'
+execute 'gc reclaimed 559mb eden [surviver: 95b/30.2mb]'
+assert_output_json_eq '{"eden_free": {"size": "559", "unit":"mb"}, "surviver_used": {"sz": "95", "u": "b"}, "surviver_size": {"value": "30.2", "suffix": "mb"}}'

--- a/tests/field_suffixed.sh
+++ b/tests/field_suffixed.sh
@@ -11,3 +11,44 @@ reset_rules
 add_rule 'rule=:gc reclaimed %eden_free:named_suffixed:size:unit:,:b,kb,mb,gb:number% eden [surviver: %surviver_used:named_suffixed:sz:u:;:kb;mb;gb;b:number%/%surviver_size:suffixed:|:b|kb|mb|gb:float%]'
 execute 'gc reclaimed 559mb eden [surviver: 95b/30.2mb]'
 assert_output_json_eq '{"eden_free": {"size": "559", "unit":"mb"}, "surviver_used": {"sz": "95", "u": "b"}, "surviver_size": {"value": "30.2", "suffix": "mb"}}'
+
+reset_rules
+
+add_rule 'rule=:gc reclaimed %eden_free:named_suffixed:size:unit:,:b,kb,mb,gb:interpret:int:number% from eden'
+execute 'gc reclaimed 559mb from eden'
+assert_output_json_eq '{"eden_free": {"size": 559, "unit":"mb"}}'
+
+reset_rules
+
+add_rule 'rule=:disk free: %free:named_suffixed:size:unit:,:\x25,gb:interpret:int:number%'
+execute 'disk free: 12%'
+assert_output_json_eq '{"free": {"size": 12, "unit":"%"}}'
+execute 'disk free: 130gb'
+assert_output_json_eq '{"free": {"size": 130, "unit":"gb"}}'
+
+reset_rules
+
+add_rule 'rule=:disk free: %free:named_suffixed:size:unit:\x3a:gb\x3a\x25:interpret:int:number%'
+execute 'disk free: 12%'
+assert_output_json_eq '{"free": {"size": 12, "unit":"%"}}'
+execute 'disk free: 130gb'
+assert_output_json_eq '{"free": {"size": 130, "unit":"gb"}}'
+
+reset_rules
+
+add_rule 'rule=:eden,surviver,old-gen available-capacity: %available_memory:tokenized:,:named_suffixed:size:unit:,:mb,gb:interpret:int:number%'
+execute 'eden,surviver,old-gen available-capacity: 400mb,40mb,1gb'
+assert_output_json_eq '{"available_memory": [{"size": 400, "unit":"mb"}, {"size": 40, "unit":"mb"}, {"size": 1, "unit":"gb"}]}'
+
+reset_rules
+
+add_rule 'rule=:eden,surviver,old-gen available-capacity: %available_memory:named_suffixed:size:unit:,:mb,gb:tokenized:,:interpret:int:number%'
+execute 'eden,surviver,old-gen available-capacity: 400,40,1024mb'
+assert_output_json_eq '{"available_memory": {"size": [400, 40, 1024], "unit":"mb"}}'
+
+reset_rules
+
+add_rule 'rule=:eden:surviver:old-gen available-capacity: %available_memory:named_suffixed:size:unit:,:mb,gb:tokenized:\x3a:interpret:int:number%'
+execute 'eden:surviver:old-gen available-capacity: 400:40:1024mb'
+assert_output_json_eq '{"available_memory": {"size": [400, 40, 1024], "unit":"mb"}}'
+

--- a/tests/field_suffixed_with_invalid_ruledef.sh
+++ b/tests/field_suffixed_with_invalid_ruledef.sh
@@ -1,0 +1,61 @@
+# added 2015-02-26 by singh.janmejay
+# This file is part of the liblognorm project, released under ASL 2.0
+source ./exec.sh $0 "field with one of many possible suffixes, but invalid ruledef"
+
+add_rule 'rule=:reclaimed %eden_free:suffixe:,:b,kb,mb,gb:number% eden'
+execute 'reclaimed 559mb eden'
+assert_output_json_eq '{ "originalmsg": "reclaimed 559mb eden", "unparsed-data": "559mb eden" }'
+
+reset_rules
+
+add_rule 'rule=:reclaimed %eden_free:suffixed% eden'
+execute 'reclaimed 559mb eden'
+assert_output_json_eq '{ "originalmsg": "reclaimed 559mb eden", "unparsed-data": "559mb eden" }'
+
+reset_rules
+
+add_rule 'rule=:reclaimed %eden_free:suffixed:% eden'
+execute 'reclaimed 559mb eden'
+assert_output_json_eq '{ "originalmsg": "reclaimed 559mb eden", "unparsed-data": "559mb eden" }'
+
+reset_rules
+
+add_rule 'rule=:reclaimed %eden_free:suffixed:kb,mb% eden'
+execute 'reclaimed 559mb eden'
+assert_output_json_eq '{ "originalmsg": "reclaimed 559mb eden", "unparsed-data": "559mb eden" }'
+
+reset_rules
+
+add_rule 'rule=:reclaimed %eden_free:suffixed:kb,mb% eden'
+execute 'reclaimed 559mb eden'
+assert_output_json_eq '{ "originalmsg": "reclaimed 559mb eden", "unparsed-data": "559mb eden" }'
+
+reset_rules
+
+add_rule 'rule=:reclaimed %eden_free:suffixed:,:% eden'
+execute 'reclaimed 559mb eden'
+assert_output_json_eq '{ "originalmsg": "reclaimed 559mb eden", "unparsed-data": "559mb eden" }'
+
+reset_rules
+
+add_rule 'rule=:reclaimed %eden_free:suffixed:,:kb,mb% eden'
+execute 'reclaimed 559mb eden'
+assert_output_json_eq '{ "originalmsg": "reclaimed 559mb eden", "unparsed-data": "559mb eden" }'
+
+reset_rules
+
+add_rule 'rule=:reclaimed %eden_free:suffixed:,:kb,mb:% eden'
+execute 'reclaimed 559mb eden'
+assert_output_json_eq '{ "originalmsg": "reclaimed 559mb eden", "unparsed-data": "559mb eden" }'
+
+reset_rules
+
+add_rule 'rule=:reclaimed %eden_free:suffixed:,:kb,mb:floa% eden'
+execute 'reclaimed 559mb eden'
+assert_output_json_eq '{ "originalmsg": "reclaimed 559mb eden", "unparsed-data": "559mb eden" }'
+
+reset_rules
+
+add_rule 'rule=:reclaimed %eden_free:suffixed:,:kb,m:b:floa% eden'
+execute 'reclaimed 559mb eden'
+assert_output_json_eq '{ "originalmsg": "reclaimed 559mb eden", "unparsed-data": "559mb eden" }'

--- a/tests/field_tokenized.sh
+++ b/tests/field_tokenized.sh
@@ -1,6 +1,7 @@
 # added 2014-11-17 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
 source ./exec.sh $0 "tokenized field"
+
 add_rule 'rule=:%arr:tokenized: , :word% %more:rest%'
 execute '123 , abc , 456 , def ijk789'
 assert_output_contains '"arr": [ "123", "abc", "456", "def" ]'
@@ -16,3 +17,8 @@ reset_rules
 add_rule 'rule=:comma separated list of colon separated list of # separated numbers: %some_nos:tokenized:, :tokenized: \x3a :tokenized:#:number%'
 execute 'comma separated list of colon separated list of # separated numbers: 10, 20 : 30#40#50 : 60#70#80, 90 : 100'
 assert_output_contains '"some_nos": [ [ [ "10" ] ], [ [ "20" ], [ "30", "40", "50" ], [ "60", "70", "80" ] ], [ [ "90" ], [ "100" ] ] ]'
+
+reset_rules
+add_rule 'rule=:%arr:tokenized:\x3a:number% %more:rest%'
+execute '123:456:789 ijk789'
+assert_output_json_eq '{"arr": [ "123", "456", "789" ], "more": "ijk789"}'

--- a/tests/json_eq.c
+++ b/tests/json_eq.c
@@ -1,3 +1,4 @@
+#include "config.h"
 #include "json_compatibility.h"
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
- Implemented float (a type that parses real numbers in form of nnn.nnn) (note that this doesn't handle n.nnne^nn or any other scientific notation, but then those are not all that common in logs)
- Implemented suffixed and named_suffixed field types that allow parsing of fields that have one of many potential suffixes (like a disk-space value which may have suffix kb, mb, gb etc). Field named_suffixed does exactly the same thing as suffixed, but allows user to name the parsed-value and suffix field unlike suffixed, which provides default names "value" and "suffix".
- Tokenized wasn't working with lognorm special characters ('%' and ':') because it wasn't unescaping token-string, which is now fixed. 