### PR TITLE
add new 'string' field type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ stamp-h1
 test-driver
 *.trs
 *.log
+*.tar.gz
 test.out
 src/ln_test
 tests/options.sh

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -211,7 +211,7 @@ up to end of line.
 
     %host:word%
 
-string
+escaped-string
 ######
 
 Parses a bash-style string, with quoting and escaping.
@@ -221,7 +221,7 @@ characters are converted to one double quote in the resulting string.
 
 ::
 
-    %field-name:string%
+    %field-name:escaped-string%
 
 string-to
 ######### 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -173,6 +173,18 @@ up to end of line.
 
     %host:word%
 
+string
+######
+
+Parses a bash-style string, with quoting and escaping.
+Characters can be escaped by preceding them with a backslash (\\).
+Additionally, inside double quotes, two consecutive double quote
+characters are converted to one double quote in the resulting string.
+
+::
+
+    %field-name:string%
+
 string-to
 ######### 
 

--- a/rulebases/syntax.txt
+++ b/rulebases/syntax.txt
@@ -63,10 +63,10 @@ Matches:		One or more characters, up to the next space (\x20), or
 Extra data:		Not used
 Example:		%field_name:word%
 
-Field type:		'string'
+Field type:		'escaped-string'
 Matches:		A bash-style string, with quoting and escaping.
 Extra data:		Not used
-Example:		%field-name:string%
+Example:		%field-name:escaped-string%
 Notes:			Characters can be escaped by preceding them with a backslash (\).
 				Additionally, inside double quotes, two consecutive double quote
 				characters are converted to one double quote in the resulting string.

--- a/rulebases/syntax.txt
+++ b/rulebases/syntax.txt
@@ -63,6 +63,14 @@ Matches:		One or more characters, up to the next space (\x20), or
 Extra data:		Not used
 Example:		%field_name:word%
 
+Field type:		'string'
+Matches:		A bash-style string, with quoting and escaping.
+Extra data:		Not used
+Example:		%field-name:string%
+Notes:			Characters can be escaped by preceding them with a backslash (\).
+				Additionally, inside double quotes, two consecutive double quote
+				characters are converted to one double quote in the resulting string.
+
 Field type:		'alpha'
 Matches:		One or more alphabetic characters, up to the next
 				whitespace, punctuation, decimal digit or ctrl.

--- a/src/parser.c
+++ b/src/parser.c
@@ -1831,6 +1831,96 @@ done:
 	return r;
 }
 
+BEGINParser(EscapedString)
+		size_t i;
+		char *cstr;
+		const char *in;
+		char *out;
+		int quoted, inQuotes, inDoubleQuotes, inEscape;
+
+		assert(str != NULL);
+		assert(offs != NULL);
+		assert(parsed != NULL);
+		i = *offs;
+		quoted = TRUE;
+		inQuotes = FALSE;
+		inDoubleQuotes = FALSE;
+		inEscape = FALSE;
+
+		CHKN(cstr = malloc(strLen-i+1));
+		in = str+i;
+		out = cstr;
+		
+		while (i<strLen) {
+			int doCopy = FALSE;
+			int endLoop = FALSE;
+			switch (*in) {
+				case '"':
+					if (inEscape) {
+						inEscape = FALSE;
+						doCopy = TRUE;
+					} else if (inQuotes) {
+						inQuotes = FALSE;
+						inDoubleQuotes = TRUE;
+					} else if (inDoubleQuotes) {
+						inQuotes = TRUE;
+						inDoubleQuotes = FALSE;
+						doCopy = TRUE;
+					} else {
+						inQuotes = TRUE;
+					}
+					break;
+				case '\\':
+					if (inEscape) {
+						inEscape = FALSE;
+						doCopy = TRUE;
+					} else {
+						inEscape = TRUE;
+					}
+					break;
+				case ' ':
+				case '\t':
+					if (inEscape) {
+						inEscape = FALSE;
+						doCopy = TRUE;
+					} else if (inQuotes) {
+						doCopy = TRUE;
+					} else {
+						endLoop = TRUE;
+					}
+					break;
+				default:
+					if (inEscape) {
+						inEscape = FALSE;
+					} else if (inDoubleQuotes) {
+						inQuotes = FALSE;
+						inDoubleQuotes = FALSE;
+					}
+					doCopy = TRUE;
+					break;
+			}
+			if (doCopy) {
+				*out++ = *in;
+			}
+			if (endLoop)
+				break;
+			in++;
+			i++;
+		}
+		
+		if(i == *offs) {
+			goto fail;
+		}
+		
+		/* success, persist */
+		*parsed = i - *offs;
+		/* terminate JSON value to save quoted string contents */
+		*out = '\0';
+		CHKN(*value = json_object_new_string(cstr));
+		free(cstr);
+
+ENDParser
+
 
 /**
  * Parse an ISO date, that is YYYY-MM-DD (exactly this format).

--- a/src/parser.h
+++ b/src/parser.h
@@ -116,6 +116,11 @@ int ln_parseRest(const char *str, size_t strlen, size_t *offs, const ln_fieldLis
 int ln_parseOpQuotedString(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);
 
 /** 
+ * Parse a quoted string with escape sequences.
+ */
+int ln_parseEscapedString(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);
+
+/** 
  * Parse a quoted string.
  */
 int ln_parseQuotedString(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);

--- a/src/samp.c
+++ b/src/samp.c
@@ -187,7 +187,7 @@ ln_parseFieldDescr(ln_ctx ctx, es_str_t *rule, es_size_t *bufOffs, es_str_t **st
 		node->parser = ln_parseRest;
 	} else if(!es_strconstcmp(*str, "op-quoted-string")) {
 		node->parser = ln_parseOpQuotedString;
-	} else if(!es_strconstcmp(*str, "string")) {
+	} else if(!es_strconstcmp(*str, "escaped-string")) {
 		node->parser = ln_parseEscapedString;
 	} else if(!es_strconstcmp(*str, "quoted-string")) {
 		node->parser = ln_parseQuotedString;

--- a/src/samp.c
+++ b/src/samp.c
@@ -201,6 +201,8 @@ ln_parseFieldDescr(ln_ctx ctx, es_str_t *rule, es_size_t *bufOffs, es_str_t **st
 		node->parser = ln_parseRest;
 	} else if(!es_strconstcmp(*str, "op-quoted-string")) {
 		node->parser = ln_parseOpQuotedString;
+	} else if(!es_strconstcmp(*str, "string")) {
+		node->parser = ln_parseEscapedString;
 	} else if(!es_strconstcmp(*str, "quoted-string")) {
 		node->parser = ln_parseQuotedString;
 	} else if(!es_strconstcmp(*str, "date-iso")) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -13,6 +13,7 @@ user_test_LDFLAGS = -no-install
 TESTS_SHELLSCRIPTS = \
 	field_hexnumber.sh \
 	field_kernel_timestamp.sh \
+	field_strings.sh \
 	field_whitespace.sh \
 	field_duration.sh \
 	field_tokenized.sh \

--- a/tests/field_strings.sh
+++ b/tests/field_strings.sh
@@ -36,7 +36,7 @@ assert_output_json_eq '{ "word": "\"test-\"\"result\"\"\"" }'
 
 reset_rules
 
-add_rule 'rule=:%str:string% end'
+add_rule 'rule=:%str:escaped-string% end'
 execute 'test-result end'
 assert_output_json_eq '{ "str": "test-result" }'
 execute '"test-result" end'
@@ -64,7 +64,7 @@ assert_output_json_eq '{ "originalmsg": "\"GET \/www.testsite.com\/RenderProduct
 
 reset_rules
 
-add_rule 'rule=:"%-:word% /%-:char-to:/%%-:word% %-:char-to:"%" %referer:string% end'
+add_rule 'rule=:"%-:word% /%-:char-to:/%%-:word% %-:char-to:"%" %referer:escaped-string% end'
 execute "$logportion"' end'
 assert_output_json_eq '{"referer": "http:\/\/w.tt.com\/cat#{\"sQuery\":\"true\",\"oc\":\"Giant 12\",\"tx\":\"\"}"}'
 

--- a/tests/field_strings.sh
+++ b/tests/field_strings.sh
@@ -1,0 +1,76 @@
+# added 2015-04-21 by Angelo Turetta
+# This file is part of the liblognorm project, released under ASL 2.0
+source ./exec.sh $0 "quoted string with escapes"
+
+logportion='"GET /www.testsite.com/RenderProducts?sQuery=true&siteCode=TEST HTTP/1.1" "http://w.tt.com/cat#{""sQuery"":""true"",""oc"":""Giant 12"",""tx"":""""}"'
+
+add_rule 'rule=:%op-quoted:op-quoted-string% end'
+execute 'test-result end'
+assert_output_json_eq '{ "op-quoted": "test-result" }'
+execute '"test-result" end'
+assert_output_json_eq '{ "op-quoted": "test-result" }'
+execute 'test-"result" end'
+assert_output_json_eq '{ "op-quoted": "test-\"result\"" }'
+execute 'test-\"result\" end'
+assert_output_json_eq '{ "op-quoted": "test-\\\"result\\\"" }'
+execute 'test-""result"" end'
+assert_output_json_eq '{ "op-quoted": "test-\"\"result\"\"" }'
+execute '"test-""result""" end'
+assert_output_json_eq '{ "originalmsg": "\"test-\"\"result\"\"\" end", "unparsed-data": "\"result\"\"\" end" }'
+
+reset_rules
+
+add_rule 'rule=:%word:word% end'
+execute 'test-result end'
+assert_output_json_eq '{ "word": "test-result" }'
+execute '"test-result" end'
+assert_output_json_eq '{ "word": "\"test-result\"" }'
+execute 'test-"result" end'
+assert_output_json_eq '{ "word": "test-\"result\"" }'
+execute 'test-\"result\" end'
+assert_output_json_eq '{ "word": "test-\\\"result\\\"" }'
+execute 'test-""result"" end'
+assert_output_json_eq '{ "word": "test-\"\"result\"\"" }'
+execute '"test-""result""" end'
+assert_output_json_eq '{ "word": "\"test-\"\"result\"\"\"" }'
+
+reset_rules
+
+add_rule 'rule=:%str:string% end'
+execute 'test-result end'
+assert_output_json_eq '{ "str": "test-result" }'
+execute '"test-result" end'
+assert_output_json_eq '{ "str": "test-result" }'
+execute 'test-"result" end'
+assert_output_json_eq '{ "str": "test-result" }'
+execute 'test-\"result\" end'
+assert_output_json_eq '{ "str": "test-\"result\"" }'
+execute 'test-""result"" end'
+assert_output_json_eq '{ "str": "test-result" }'
+execute '"test-""result""" end'
+assert_output_json_eq '{ "str": "test-\"result\"" }'
+
+reset_rules
+
+add_rule 'rule=:"%-:word% /%-:char-to:/%%-:word% %-:char-to:"%" %referer:op-quoted-string% end'
+execute "$logportion"' end'
+assert_output_json_eq '{ "originalmsg": "\"GET \/www.testsite.com\/RenderProducts?sQuery=true&siteCode=TEST HTTP\/1.1\" \"http:\/\/w.tt.com\/cat#{\"\"sQuery\"\":\"\"true\"\",\"\"oc\"\":\"\"Giant 12\"\",\"\"tx\"\":\"\"\"\"}\" end", "unparsed-data": "\"sQuery\"\":\"\"true\"\",\"\"oc\"\":\"\"Giant 12\"\",\"\"tx\"\":\"\"\"\"}\" end" }'
+
+reset_rules
+
+add_rule 'rule=:"%-:word% /%-:char-to:/%%-:word% %-:char-to:"%" %referer:word% end'
+execute "$logportion"' end'
+assert_output_json_eq '{ "originalmsg": "\"GET \/www.testsite.com\/RenderProducts?sQuery=true&siteCode=TEST HTTP\/1.1\" \"http:\/\/w.tt.com\/cat#{\"\"sQuery\"\":\"\"true\"\",\"\"oc\"\":\"\"Giant 12\"\",\"\"tx\"\":\"\"\"\"}\" end", "unparsed-data": "12\"\",\"\"tx\"\":\"\"\"\"}\" end" }'
+
+reset_rules
+
+add_rule 'rule=:"%-:word% /%-:char-to:/%%-:word% %-:char-to:"%" %referer:string% end'
+execute "$logportion"' end'
+assert_output_json_eq '{"referer": "http:\/\/w.tt.com\/cat#{\"sQuery\":\"true\",\"oc\":\"Giant 12\",\"tx\":\"\"}"}'
+
+#add_rule 'rule=:begin %timestamp:kernel-timestamp%'
+#execute 'begin [12345.123456]'
+#assert_output_json_eq '{ "timestamp": "[12345.123456]"}'
+
+#reset_rules
+


### PR DESCRIPTION
The new parser has some initial support for escape sequences

Please look at the new test file to understand differences between 'word', 'op-quoted-string' and the new 'string'.

I suppose the new one can be a candidate to replace 'quoted-string' and 'op-quoted-string', maybe after adding some flags to better control escaping.