### PR TITLE
call "rest" parser only if nothing else matches.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -7,6 +7,13 @@ Version 1.1.2, 2015-03-??
   broader CHKN/CHKR macros and also restructured/simplified the 
   parser generation macros.
   closes https://github.com/rsyslog/liblognorm/issues/41
+- call "rest" parser only if nothing else matches.
+  Versions prior to 1.1.2 did execute "rest" during regular parser
+  processing, and thus parser matches have been more or less random.
+  With 1.1.2 this is now always the last parser called. This may cause
+  problems with existing rulesets, HOWEVER, adding any other rule or
+  changing the load order would also have caused problems, so there
+  really is no compatibility to preserve.
 ----------------------------------------------------------------------
 Version 1.1.1, 2015-03-09
 - fixed library version numbering

--- a/ChangeLog
+++ b/ChangeLog
@@ -14,6 +14,8 @@ Version 1.1.2, 2015-03-??
   problems with existing rulesets, HOWEVER, adding any other rule or
   changing the load order would also have caused problems, so there
   really is no compatibility to preserve.
+  see also:
+  http://blog.gerhards.net/2015/04/liblognorms-rest-parser-now-more-useful.html
 ----------------------------------------------------------------------
 Version 1.1.1, 2015-03-09
 - fixed library version numbering

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -233,6 +233,8 @@ only invoked if no other parser or string literal matches.
 
     %field_name:rest%
 
+See also `Rainer's blog posting on the "rest" parser <http://blog.gerhards.net/2015/04/liblognorms-rest-parser-now-more-useful.html>`_. 
+
 quoted-string
 #############   
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -221,12 +221,13 @@ which can be escaped.
 rest
 ####
 
-Zero or more characters till end of line. Should be always at end of the 
-rule.
+Zero or more characters till end of line. Must always be at end of the 
+rule, even though this condition is currently **not** checked. In any case,
+any definitions after *rest* are ignored.
 
-**Note that the *rest* syntax should be avoided because it generates
-a very broad match. If used, it is impossible to match on a specific 
-character that is on the same position where *rest* is used.**
+Note that the *rest* syntax should be avoided because it generates
+a very broad match. To mitigate this effect, the rest parser is always
+only invoked if no other parser or string literal matches.
 
 ::
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -2026,7 +2026,7 @@ success: /* success, persist */
 	r = 0; /* success */
 done:
 	if(r != 0 && value != NULL && *value != NULL) {
-		json_object_put(value);
+		json_object_put(*value);
 		*value = NULL; /* to be on the save side */
 	}
 	return r;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,6 +14,7 @@ TESTS_SHELLSCRIPTS = \
 	field_hexnumber.sh \
 	field_kernel_timestamp.sh \
 	field_whitespace.sh \
+	field_rest.sh \
 	field_duration.sh \
 	field_cisco-interface-spec.sh \
 	field_tokenized.sh \

--- a/tests/field_rest.sh
+++ b/tests/field_rest.sh
@@ -1,0 +1,36 @@
+# some more tests for the "rest" motif, especially to ensure that
+# "rest" will not interfere with more specific rules.
+# added 2015-04-27
+# This file is part of the liblognorm project, released under ASL 2.0
+source ./exec.sh $0 "rest matches"
+
+#tail recursion with default tail field
+add_rule 'rule=:%iface:char-to:\x3a%\x3a%ip:ipv4%/%port:number% (%label2:char-to:)%)'
+add_rule 'rule=:%iface:char-to:\x3a%\x3a%ip:ipv4%/%port:number% (%label2:char-to:)%)%tail:rest%'
+add_rule 'rule=:%iface:char-to:\x3a%\x3a%ip:ipv4%/%port:number%'
+add_rule 'rule=:%iface:char-to:\x3a%\x3a%ip:ipv4%/%port:number%%tail:rest%'
+
+# real-world cisco samples
+execute 'Outside:10.20.30.40/35 (40.30.20.10/35)'
+assert_output_json_eq '{ "label2": "40.30.20.10\/35", "port": "35", "ip": "10.20.30.40", "iface": "Outside" }'
+
+execute 'Outside:10.20.30.40/35 (40.30.20.10/35) with rest'
+assert_output_json_eq '{  "tail": " with rest", "label2": "40.30.20.10\/35", "port": "35", "ip": "10.20.30.40", "iface": "Outside" }'
+
+execute 'Outside:10.20.30.40/35 (40.30.20.10/35 brace missing'
+assert_output_json_eq '{ "tail": " (40.30.20.10\/35 brace missing", "port": "35", "ip": "10.20.30.40", "iface": "Outside" }'
+
+execute 'Outside:10.20.30.40/35 40.30.20.10/35'
+assert_output_json_eq '{ "tail": " 40.30.20.10\/35", "port": "35", "ip": "10.20.30.40", "iface": "Outside" }'
+
+#
+# test expected mismatches
+#
+execute 'not at all!'
+assert_output_json_eq '{ "originalmsg": "not at all!", "unparsed-data": "not at all!" }'
+
+execute 'Outside 10.20.30.40/35 40.30.20.10/35'
+assert_output_json_eq '{ "originalmsg": "Outside 10.20.30.40\/35 40.30.20.10\/35", "unparsed-data": "Outside 10.20.30.40\/35 40.30.20.10\/35" }'
+
+execute 'Outside:10.20.30.40/aa 40.30.20.10/35'
+assert_output_json_eq '{ "originalmsg": "Outside:10.20.30.40\/aa 40.30.20.10\/35", "unparsed-data": "aa 40.30.20.10\/35" }'


### PR DESCRIPTION
Versions prior to 1.1.2 did execute "rest" during regular parser processing, and thus parser matches have been more or less random. With 1.1.2 this is now always the last parser called. This may cause problems with existing rulesets, HOWEVER, adding any other rule or changing the load order would also have caused problems, so there really is no compatibility to preserve.
