### PR TITLE
Add parser for name/value pairs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ Version 1.1.2, 2015-03-??
 - new parser "cisco-interface-spec"
 - new parser "json" to process json parts of the message
 - new parser "mac48" to process mac layer addresses
+- new parser "name-value-list" (currently inofficial, experimental)
 - some parsers did incorrectly report success when an error occurred
   this was caused by inconsistencies between various macros. We have
   changed the parser-generation macros to match the semantics of the

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.61)
-AC_INIT([liblognorm], [1.1.2.master], [rgerhards@adiscon.com])
+AC_INIT([liblognorm], [1.1.2.master], [rgerhards@adiscon.com], [subdir-objects])
 AM_INIT_AUTOMAKE
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_SRCDIR([src/lognorm.c])

--- a/src/parser.c
+++ b/src/parser.c
@@ -2408,6 +2408,59 @@ done:
 	return r;
 }
 
+
+/* helper to NameValue parser, parses out a a single name=value pair 
+ *
+ * name must be alphanumeric characters, value must be non-whitespace
+ * characters, if quoted than with symmetric quotes. Supported formats
+ * - name=value
+ * - name="value"
+ * - name='value'
+ * Note "name=" is valid and means a field with empty value.
+ * TODO: so far, quote characters are not permitted WITHIN quoted values.
+ */
+static int
+parseNameValue(const char *const __restrict__ str,
+	const size_t strLen, 
+	size_t *const __restrict__ offs,
+	struct json_object *const __restrict__ valroot)
+{
+	int r = LN_WRONGPARSER;
+	size_t i = *offs;
+
+	const size_t iName = i;
+	while(i < strLen && isalnum(str[i]))
+		++i;
+	if(i == iName || str[i] != '=')
+		goto done; /* no name at all! */
+
+	const size_t lenName = i - iName;
+	++i; /* skip '=' */
+
+	const size_t iVal = i;
+	while(i < strLen && !isspace(str[i]))
+		++i;
+	const size_t lenVal = i - iVal;
+
+	/* parsing OK */
+	*offs = i;
+	r = 0;
+
+	if(valroot == NULL)
+		goto done;
+
+	char *name;
+	CHKN(name = malloc(lenName+1));
+	memcpy(name, str+iName, lenName);
+	name[lenName] = '\0';
+	json_object *json;
+	CHKN(json = json_object_new_string_len(str+iVal, lenVal));
+	json_object_object_add(valroot, name, json);
+	free(name);
+done:
+	return r;
+}
+
 /**
  * Parse CEE syslog.
  * This essentially is a JSON parser, with additional restrictions:
@@ -2463,6 +2516,50 @@ done:
 		json_tokener_free(tokener);
 	if(json != NULL)
 		json_object_put(json);
+	return r;
+}
+
+/**
+ * Parser for name/value pairs.
+ * On entry must point to alnum char. All following chars must be
+ * name/value pairs delimited by whitespace up until the end of string.
+ * For performance reasons, this works in two stages. In the first
+ * stage, we only detect if the motif is correct. The second stage is
+ * only called when we know it is. In it, we go once again over the
+ * message again and actually extract the data. This is done because
+ * data extraction is relatively expensive and in most cases we will
+ * have much more frequent mismatches than matches.
+ * added 2015-04-25 rgerhards
+ */
+PARSER(NameValue)
+	size_t i = *offs;
+
+	/* stage one */
+	while(i < strLen) {
+		CHKR(parseNameValue(str, strLen, &i, NULL));
+		while(i < strLen && isspace(str[i]))
+			++i;
+	}
+
+	/* success, persist */
+	*parsed = i - *offs;
+	r = 0; /* success */
+
+	/* stage two */
+	if(value == NULL)
+		goto done;
+
+	i = *offs;
+	CHKN(*value = json_object_new_object());
+	while(i < strLen) {
+		CHKR(parseNameValue(str, strLen, &i, *value));
+		while(i < strLen && isspace(str[i]))
+			++i;
+	}
+
+	/* TODO: fix mem leak if alloc json fails */
+
+done:
 	return r;
 }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -2409,6 +2409,20 @@ done:
 }
 
 
+/* check if a char is valid inside a name of a NameValue list
+ * The set of valid characters may be extended if there is good
+ * need to do so. We have selected the current set carefully, but
+ * may have overlooked some cases.
+ */
+static inline int
+isValidNameChar(const char c)
+{
+	return (isalnum(c)
+		|| c == '.'
+		|| c == '_'
+		|| c == '-'
+		) ? 1 : 0;
+}
 /* helper to NameValue parser, parses out a a single name=value pair 
  *
  * name must be alphanumeric characters, value must be non-whitespace
@@ -2429,7 +2443,7 @@ parseNameValue(const char *const __restrict__ str,
 	size_t i = *offs;
 
 	const size_t iName = i;
-	while(i < strLen && isalnum(str[i]))
+	while(i < strLen && isValidNameChar(str[i]))
 		++i;
 	if(i == iName || str[i] != '=')
 		goto done; /* no name at all! */

--- a/src/parser.h
+++ b/src/parser.h
@@ -172,6 +172,11 @@ int ln_parseCiscoInterfaceSpec(const char *str, size_t strlen, size_t *offs, con
 int ln_parseMAC48(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);
 
 /** 
+ * Parser for name/value pairs.
+ */
+int ln_parseNameValue(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);
+
+/** 
  * Get all tokens separated by tokenizer-string as array.
  */
 int ln_parseTokenized(const char *str, size_t strlen, size_t *offs, const ln_fieldList_t *node, size_t *parsed, struct json_object **value);

--- a/src/samp.c
+++ b/src/samp.c
@@ -219,19 +219,21 @@ ln_parseFieldDescr(ln_ctx ctx, es_str_t *rule, es_size_t *bufOffs, es_str_t **st
 		node->parser = ln_parseCEESyslog;
 	} else if(!es_strconstcmp(*str, "mac48")) {
 		node->parser = ln_parseMAC48;
+	} else if(!es_strconstcmp(*str, "name-value-list")) {
+		node->parser = ln_parseNameValue;
 	} else if(!es_strconstcmp(*str, "v2-iptables")) {
 		node->parser = ln_parsev2IPTables;
 	} else if(!es_strconstcmp(*str, "iptables")) {
 		node->parser = NULL;
 		node->isIPTables = 1;
 	} else if(!es_strconstcmp(*str, "string-to")) {
-		// TODO: check extra data!!!! (very important)
+		/* TODO: check extra data!!!! (very important) */
 		node->parser = ln_parseStringTo;
 	} else if(!es_strconstcmp(*str, "char-to")) {
-		// TODO: check extra data!!!! (very important)
+		/* TODO: check extra data!!!! (very important) */
 		node->parser = ln_parseCharTo;
 	} else if(!es_strconstcmp(*str, "char-sep")) {
-		// TODO: check extra data!!!! (very important)
+		/* TODO: check extra data!!!! (very important) */
 		node->parser = ln_parseCharSeparated;
 	} else if(!es_strconstcmp(*str, "tokenized")) {
 		node->parser = ln_parseTokenized;
@@ -779,7 +781,7 @@ ln_processSamp(ln_ctx ctx, const char *buf, es_size_t lenBuf)
 	} else if(!es_strconstcmp(typeStr, "annotate")) {
 		if(processAnnotate(ctx, buf, lenBuf, offs) != 0) goto done;
 	} else {
-		// TODO error reporting
+		/* TODO error reporting */
 		char *str;
 		str = es_str2cstr(typeStr, NULL);
 		ln_dbgprintf(ctx, "invalid record type detected: '%s'", str);
@@ -800,7 +802,7 @@ ln_sampRead(ln_ctx ctx, struct ln_sampRepos *repo, int *isEof)
 {
 	struct ln_samp *samp = NULL;
 	int done = 0;
-	char buf[10*1024]; /**< max size of rule */ // TODO: make configurable
+	char buf[10*1024]; /**< max size of rule - TODO: make configurable */
 	es_size_t lenBuf;
 
 	/* we ignore empty lines and lines that begin with "#" */
@@ -824,7 +826,7 @@ ln_sampRead(ln_ctx ctx, struct ln_sampRepos *repo, int *isEof)
 	}
 
 	ln_dbgprintf(ctx, "read sample line: '%s'", buf);
-    ln_processSamp(ctx, buf, lenBuf);
+	ln_processSamp(ctx, buf, lenBuf);
 
 done:
 	return samp;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -13,6 +13,7 @@ user_test_LDFLAGS = -no-install
 TESTS_SHELLSCRIPTS = \
 	field_hexnumber.sh \
 	field_mac48.sh \
+	field_name_value.sh \
 	field_kernel_timestamp.sh \
 	field_whitespace.sh \
 	field_rest.sh \

--- a/tests/field_name_value.sh
+++ b/tests/field_name_value.sh
@@ -1,0 +1,23 @@
+# added 2015-04-25 by Rainer Gerhards
+# This file is part of the liblognorm project, released under ASL 2.0
+source ./exec.sh $0 "name/value parser"
+add_rule 'rule=:%f:name-value-list%'
+
+execute 'name=value'
+assert_output_json_eq '{ "f": { "name": "value" } }'
+
+execute 'name1=value1 name2=value2 name3=value3'
+assert_output_json_eq '{ "f": { "name1": "value1", "name2": "value2", "name3": "value3" } }'
+
+execute 'name1=value1 name2=value2 name3=value3 '
+assert_output_json_eq '{ "f": { "name1": "value1", "name2": "value2", "name3": "value3" } }'
+
+execute 'name1= name2=value2 name3=value3 '
+assert_output_json_eq '{ "f": { "name1": "", "name2": "value2", "name3": "value3" } }'
+
+# check for required non-matches
+execute 'name'
+assert_output_json_eq ' {"originalmsg": "name", "unparsed-data": "name" }'
+
+execute 'noname1 name2=value2 name3=value3 '
+assert_output_json_eq '{ "originalmsg": "noname1 name2=value2 name3=value3", "unparsed-data": "noname1 name2=value2 name3=value3" }'

--- a/tests/field_name_value.sh
+++ b/tests/field_name_value.sh
@@ -23,4 +23,4 @@ execute 'name'
 assert_output_json_eq ' {"originalmsg": "name", "unparsed-data": "name" }'
 
 execute 'noname1 name2=value2 name3=value3 '
-assert_output_json_eq '{ "originalmsg": "noname1 name2=value2 name3=value3", "unparsed-data": "noname1 name2=value2 name3=value3" }'
+assert_output_json_eq '{ "originalmsg": "noname1 name2=value2 name3=value3 ", "unparsed-data": "noname1 name2=value2 name3=value3 " }'

--- a/tests/field_name_value.sh
+++ b/tests/field_name_value.sh
@@ -15,6 +15,9 @@ assert_output_json_eq '{ "f": { "name1": "value1", "name2": "value2", "name3": "
 execute 'name1= name2=value2 name3=value3 '
 assert_output_json_eq '{ "f": { "name1": "", "name2": "value2", "name3": "value3" } }'
 
+execute 'origin=core.action processed=67 failed=0 suspended=0 suspended.duration=0 resumed=0 '
+assert_output_json_eq '{ "f": { "origin": "core.action", "processed": "67", "failed": "0", "suspended": "0", "suspended.duration": "0", "resumed": "0" } }'
+
 # check for required non-matches
 execute 'name'
 assert_output_json_eq ' {"originalmsg": "name", "unparsed-data": "name" }'


### PR DESCRIPTION
This merges the current state. It is useful as is, but it will improve. Still, it's time to merge, especially as part of the functionality can be used to support CEF (https://github.com/rsyslog/liblognorm/issues/40). After the merge, this is flagged as "officially unsupported/experimental" with the desire to change that with later commits.