### PR TITLE
Fixed clang (static-analysis) identified bugs + test-name/desc print-out in test-logs on FreeBSD

### DIFF
--- a/tests/exec.sh
+++ b/tests/exec.sh
@@ -1,10 +1,5 @@
-test_file=$(basename $1)
-test_name=$(echo $test_file | sed -e 's/\..*//g')
-
-echo ===============================================================================
-echo "[${test_file}]: test for ${2}"
-
 set -e
+
 if [ "x$debug" == "xon" ]; then #get core-dump on crash
     ulimit -c unlimited
 fi
@@ -12,6 +7,14 @@ fi
 cmd=../src/ln_test
 
 . ./options.sh
+
+test_def() {
+    test_file=$(basename $1)
+    test_name=$(echo $test_file | sed -e 's/\..*//g')
+
+    echo ===============================================================================
+    echo "[${test_file}]: test for ${2}"
+}
 
 execute() {
     if [ "x$debug" == "xon" ]; then

--- a/tests/field_cee-syslog.sh
+++ b/tests/field_cee-syslog.sh
@@ -1,6 +1,8 @@
 # added 2015-03-01 by Rainer Gerhards
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "JSON field"
+. ./exec.sh
+
+test_def $0 "JSON field"
 add_rule 'rule=:%field:cee-syslog%'
 
 execute '@cee:{"f1": "1", "f2": 2}'

--- a/tests/field_cef.sh
+++ b/tests/field_cef.sh
@@ -1,6 +1,8 @@
 # added 2015-05-05 by Rainer Gerhards
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "CEF parser"
+. ./exec.sh
+
+test_def $0 "CEF parser"
 add_rule 'rule=:%f:cef%'
 
 # fabricated tests to test specific functionality

--- a/tests/field_checkpoint-lea.sh
+++ b/tests/field_checkpoint-lea.sh
@@ -1,6 +1,8 @@
 # added 2015-06-18 by Rainer Gerhards
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "Checkpoint LEA parser"
+. ./exec.sh
+
+test_def $0 "Checkpoint LEA parser"
 add_rule 'rule=:%f:checkpoint-lea%'
 
 execute 'tcp_flags: RST-ACK; src: 192.168.0.1;'

--- a/tests/field_cisco-interface-spec.sh
+++ b/tests/field_cisco-interface-spec.sh
@@ -1,6 +1,8 @@
 # added 2015-04-13 by Rainer Gerhards
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "cisco-interface-spec syntax"
+. ./exec.sh
+
+test_def $0 "cisco-interface-spec syntax"
 add_rule 'rule=:begin %field:cisco-interface-spec% end'
 
 execute 'begin outside:176.97.252.102/50349 end'

--- a/tests/field_descent.sh
+++ b/tests/field_descent.sh
@@ -1,6 +1,8 @@
 # added 2014-12-11 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "descent based parsing field"
+. ./exec.sh
+
+test_def $0 "descent based parsing field"
 
 #descent with default tail field
 add_rule 'rule=:blocked on %device:word% %net:descent:'$srcdir'/child.rulebase%at %tm:date-rfc5424%'

--- a/tests/field_descent_with_invalid_ruledef.sh
+++ b/tests/field_descent_with_invalid_ruledef.sh
@@ -1,6 +1,8 @@
 # added 2014-12-15 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "descent based parsing field, with invalid ruledef"
+. ./exec.sh
+
+test_def $0 "descent based parsing field, with invalid ruledef"
 
 #invalid parent field name
 add_rule 'rule=:%net:desce%'

--- a/tests/field_duration.sh
+++ b/tests/field_duration.sh
@@ -1,6 +1,8 @@
 # added 2015-03-12 by Rainer Gerhards
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "duration syntax"
+. ./exec.sh
+
+test_def $0 "duration syntax"
 add_rule 'rule=:duration %field:duration% bytes'
 add_rule 'rule=:duration %field:duration%'
 

--- a/tests/field_float.sh
+++ b/tests/field_float.sh
@@ -1,6 +1,8 @@
 # added 2015-02-25 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "float field"
+. ./exec.sh
+
+test_def $0 "float field"
 add_rule 'rule=:here is a number %num:float% in floating pt form'
 execute 'here is a number 15.9 in floating pt form'
 assert_output_json_eq '{"num": "15.9"}'

--- a/tests/field_float_with_invalid_ruledef.sh
+++ b/tests/field_float_with_invalid_ruledef.sh
@@ -1,6 +1,8 @@
 # added 2015-02-26 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "float with invalid field-declaration"
+. ./exec.sh
+
+test_def $0 "float with invalid field-declaration"
 
 add_rule 'rule=:%no:flo% foo'
 execute '10.0 foo'

--- a/tests/field_hexnumber.sh
+++ b/tests/field_hexnumber.sh
@@ -1,7 +1,9 @@
 # added 2015-03-01 by Rainer Gerhards
 # This file is part of the liblognorm project, released under ASL 2.0
 
-. ./exec.sh $0 "hexnumber field"
+. ./exec.sh
+
+test_def $0 "hexnumber field"
 add_rule 'rule=:here is a number %num:hexnumber% in hex form'
 execute 'here is a number 0x1234 in hex form'
 assert_output_json_eq '{"num": "0x1234"}'

--- a/tests/field_interpret.sh
+++ b/tests/field_interpret.sh
@@ -1,6 +1,8 @@
 # added 2014-12-11 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "value interpreting field"
+. ./exec.sh
+
+test_def $0 "value interpreting field"
 
 add_rule 'rule=:%session_count:interpret:int:word% sessions established'
 execute '64 sessions established'

--- a/tests/field_interpret_with_invalid_ruledef.sh
+++ b/tests/field_interpret_with_invalid_ruledef.sh
@@ -1,6 +1,8 @@
 # added 2014-12-11 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "value interpreting field, with invalid ruledef"
+. ./exec.sh
+
+test_def $0 "value interpreting field, with invalid ruledef"
 
 add_rule 'rule=:%session_count:interpret:int:wd% sessions established'
 execute '64 sessions established'

--- a/tests/field_ipv6.sh
+++ b/tests/field_ipv6.sh
@@ -1,6 +1,8 @@
 # added 2015-06-23 by Rainer Gerhards
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "IPv6 parser"
+. ./exec.sh
+
+test_def $0 "IPv6 parser"
 add_rule 'rule=:%f:ipv6%'
 
 # examples from RFC4291, sect. 2.2

--- a/tests/field_json.sh
+++ b/tests/field_json.sh
@@ -1,6 +1,8 @@
 # added 2015-03-01 by Rainer Gerhards
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "JSON field"
+. ./exec.sh
+
+test_def $0 "JSON field"
 add_rule 'rule=:%field:json%'
 
 execute '{"f1": "1", "f2": 2}'

--- a/tests/field_kernel_timestamp.sh
+++ b/tests/field_kernel_timestamp.sh
@@ -1,6 +1,8 @@
 # added 2015-03-12 by Rainer Gerhards
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "kernel timestamp parser"
+. ./exec.sh
+
+test_def $0 "kernel timestamp parser"
 add_rule 'rule=:begin %timestamp:kernel-timestamp% end'
 execute 'begin [12345.123456] end'
 assert_output_json_eq '{ "timestamp": "[12345.123456]"}'

--- a/tests/field_mac48.sh
+++ b/tests/field_mac48.sh
@@ -1,6 +1,8 @@
 # added 2015-05-05 by Rainer Gerhards
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "dmac48 syntax"
+. ./exec.sh
+
+test_def $0 "dmac48 syntax"
 add_rule 'rule=:%field:mac48%'
 
 execute 'f0:f6:1c:5f:cc:a2'

--- a/tests/field_name_value.sh
+++ b/tests/field_name_value.sh
@@ -1,6 +1,8 @@
 # added 2015-04-25 by Rainer Gerhards
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "name/value parser"
+. ./exec.sh
+
+test_def $0 "name/value parser"
 add_rule 'rule=:%f:name-value-list%'
 
 execute 'name=value'

--- a/tests/field_recursive.sh
+++ b/tests/field_recursive.sh
@@ -1,6 +1,8 @@
 # added 2014-11-26 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "recursive parsing field"
+. ./exec.sh
+
+test_def $0 "recursive parsing field"
 
 #tail recursion with default tail field
 add_rule 'rule=:%word:word% %next:recursive%'

--- a/tests/field_regex_default_group_parse_and_return.sh
+++ b/tests/field_regex_default_group_parse_and_return.sh
@@ -1,7 +1,9 @@
 # added 2014-11-14 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
 export ln_opts='-oallowRegex'
-. ./exec.sh $0 "type ERE for regex field"
+. ./exec.sh
+
+test_def $0 "type ERE for regex field"
 add_rule 'rule=:%first:regex:[a-z]+% %second:regex:\d+\x25\x3a[a-f0-9]+\x25%'
 execute 'foo 122%:7a%'
 assert_output_contains '"first": "foo"'

--- a/tests/field_regex_invalid_args.sh
+++ b/tests/field_regex_invalid_args.sh
@@ -1,7 +1,9 @@
 # added 2014-11-14 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
 export ln_opts='-oallowRegex'
-. ./exec.sh $0 "invalid type for regex field with everything else defaulted"
+. ./exec.sh
+
+test_def $0 "invalid type for regex field with everything else defaulted"
 
 add_rule 'rule=:%first:regex:[a-z]+:Q%'
 execute 'foo'

--- a/tests/field_regex_while_regex_support_is_disabled.sh
+++ b/tests/field_regex_while_regex_support_is_disabled.sh
@@ -1,6 +1,8 @@
 # added 2014-11-14 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "field regex, while regex support is disabled"
+. ./exec.sh
+
+test_def $0 "field regex, while regex support is disabled"
 add_rule 'rule=:%first:regex:[a-z]+%'
 execute 'foo'
 assert_output_contains '"originalmsg": "foo"'

--- a/tests/field_regex_with_consume_group.sh
+++ b/tests/field_regex_with_consume_group.sh
@@ -1,7 +1,9 @@
 # added 2014-11-14 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
 export ln_opts='-oallowRegex'
-. ./exec.sh $0 "regex field with consume-group"
+. ./exec.sh
+
+test_def $0 "regex field with consume-group"
 add_rule 'rule=:%first:regex:([a-z]{2}([a-f0-9]+,)+):0%%rest:rest%'
 execute 'ad1234abcd,4567ef12,8901abef'
 assert_output_contains '"first": "ad1234abcd,4567ef12,"'

--- a/tests/field_regex_with_consume_group_and_return_group.sh
+++ b/tests/field_regex_with_consume_group_and_return_group.sh
@@ -1,7 +1,9 @@
 # added 2014-11-14 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
 export ln_opts='-oallowRegex'
-. ./exec.sh $0 "regex field with consume-group and return-group"
+. ./exec.sh
+
+test_def $0 "regex field with consume-group and return-group"
 set -x
 add_rule 'rule=:%first:regex:[a-z]{2}(([a-f0-9]+),)+:0:2%%rest:rest%'
 execute 'ad1234abcd,4567ef12,8901abef'

--- a/tests/field_regex_with_negation.sh
+++ b/tests/field_regex_with_negation.sh
@@ -1,7 +1,9 @@
 # added 2014-11-17 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
 export ln_opts='-oallowRegex'
-. ./exec.sh $0 "regex field with negation"
+. ./exec.sh
+
+test_def $0 "regex field with negation"
 add_rule 'rule=:%text:regex:[^,]+%,%more:rest%'
 execute '123,abc'
 assert_output_contains '"text": "123"'

--- a/tests/field_rest.sh
+++ b/tests/field_rest.sh
@@ -2,7 +2,9 @@
 # "rest" will not interfere with more specific rules.
 # added 2015-04-27
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "rest matches"
+. ./exec.sh
+
+test_def $0 "rest matches"
 
 #tail recursion with default tail field
 add_rule 'rule=:%iface:char-to:\x3a%\x3a%ip:ipv4%/%port:number% (%label2:char-to:)%)'

--- a/tests/field_suffixed.sh
+++ b/tests/field_suffixed.sh
@@ -1,6 +1,8 @@
 # added 2015-02-25 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "field with one of many possible suffixes"
+. ./exec.sh
+
+test_def $0 "field with one of many possible suffixes"
 
 add_rule 'rule=:gc reclaimed %eden_free:suffixed:,:b,kb,mb,gb:number% eden [surviver: %surviver_used:suffixed:;:kb;mb;gb;b:number%/%surviver_size:suffixed:|:b|kb|mb|gb:float%]'
 execute 'gc reclaimed 559mb eden [surviver: 95b/30.2mb]'

--- a/tests/field_suffixed_with_invalid_ruledef.sh
+++ b/tests/field_suffixed_with_invalid_ruledef.sh
@@ -1,6 +1,8 @@
 # added 2015-02-26 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "field with one of many possible suffixes, but invalid ruledef"
+. ./exec.sh
+
+test_def $0 "field with one of many possible suffixes, but invalid ruledef"
 
 add_rule 'rule=:reclaimed %eden_free:suffixe:,:b,kb,mb,gb:number% eden'
 execute 'reclaimed 559mb eden'

--- a/tests/field_tokenized.sh
+++ b/tests/field_tokenized.sh
@@ -1,6 +1,8 @@
 # added 2014-11-17 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "tokenized field"
+. ./exec.sh
+
+test_def $0 "tokenized field"
 
 add_rule 'rule=:%arr:tokenized: , :word% %more:rest%'
 execute '123 , abc , 456 , def ijk789'

--- a/tests/field_tokenized_recursive.sh
+++ b/tests/field_tokenized_recursive.sh
@@ -1,6 +1,8 @@
 # added 2014-12-08 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "tokenized field with recursive field matching tokens"
+. ./exec.sh
+
+test_def $0 "tokenized field with recursive field matching tokens"
 
 #recursive field inside tokenized field with default tail field
 add_rule 'rule=:%subnet_addr:ipv4%/%subnet_mask:number%%tail:rest%'

--- a/tests/field_tokenized_with_invalid_ruledef.sh
+++ b/tests/field_tokenized_with_invalid_ruledef.sh
@@ -1,6 +1,8 @@
 # added 2014-11-18 by singh.janmejay
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "tokenized field with invalid rule definition"
+. ./exec.sh
+
+test_def $0 "tokenized field with invalid rule definition"
 
 add_rule 'rule=:%arr:tokenized%'
 execute '123 abc 456 def'

--- a/tests/field_tokenized_with_regex.sh
+++ b/tests/field_tokenized_with_regex.sh
@@ -2,7 +2,9 @@
 # This file is part of the liblognorm project, released under ASL 2.0
 
 #test that tokenized disabled regex if parent context has it disabled
-. ./exec.sh $0 "tokenized field with regex based field"
+. ./exec.sh
+
+test_def $0 "tokenized field with regex based field"
 add_rule 'rule=:%parts:tokenized:,:regex:[^, ]+% %text:rest%'
 execute '123,abc,456,def foo bar'
 assert_output_contains '"unparsed-data": "123,abc,456,def foo bar"'
@@ -10,7 +12,9 @@ assert_output_contains '"originalmsg": "123,abc,456,def foo bar"'
 
 #and then enables it when parent context has it enabled
 export ln_opts='-oallowRegex'
-. ./exec.sh $0 "tokenized field with regex based field"
+. ./exec.sh
+
+test_def $0 "tokenized field with regex based field"
 add_rule 'rule=:%parts:tokenized:,:regex:[^, ]+% %text:rest%'
 execute '123,abc,456,def foo bar'
 assert_output_contains '"parts": [ "123", "abc", "456", "def" ]'

--- a/tests/field_v2-iptables.sh
+++ b/tests/field_v2-iptables.sh
@@ -1,6 +1,8 @@
 # added 2015-04-30 by Rainer Gerhards
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "v2-iptables field"
+. ./exec.sh
+
+test_def $0 "v2-iptables field"
 add_rule 'rule=:iptables output denied: %field:v2-iptables%'
 
 # first, a real-world case

--- a/tests/field_whitespace.sh
+++ b/tests/field_whitespace.sh
@@ -1,6 +1,8 @@
 # added 2015-03-12 by Rainer Gerhards
 # This file is part of the liblognorm project, released under ASL 2.0
-. ./exec.sh $0 "whitespace parser"
+. ./exec.sh
+
+test_def $0 "whitespace parser"
 # the "word" parser unfortunatly treats everything except
 # a SP as being in the word. So a HT inside a word is
 # permitted, which does not work well with what we

--- a/tests/parser_LF.sh
+++ b/tests/parser_LF.sh
@@ -2,7 +2,9 @@
 # This checks if whitespace inside parser definitions is properly treated
 # This file is part of the liblognorm project, released under ASL 2.0
 
-. ./exec.sh $0 "LF in parser definition"
+. ./exec.sh
+
+test_def $0 "LF in parser definition"
 add_rule 'rule=:here is a number %
                 num:hexnumber
                 % in hex form'

--- a/tests/parser_whitespace.sh
+++ b/tests/parser_whitespace.sh
@@ -2,7 +2,9 @@
 # This checks if whitespace inside parser definitions is properly treated
 # This file is part of the liblognorm project, released under ASL 2.0
 
-. ./exec.sh $0 "whitespace in parser definition"
+. ./exec.sh
+
+test_def $0 "whitespace in parser definition"
 add_rule 'rule=:here is a number %   num:hexnumber   % in hex form'
 execute 'here is a number 0x1234 in hex form'
 assert_output_json_eq '{"num": "0x1234"}'


### PR DESCRIPTION
- clang static-analysis problems fixed 
- FreeBSD test-suite support patch didn't fix things completely, passing arguments to '.' or 'source' in sh doesn't work (unlike bash), so created a function to allow user to identify the test name and description and fixed all tests to use the new-mechanism which works across bash and sh