### PR TITLE
Added strndup workaround from rsyslog into liblognorm.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = src
+SUBDIRS = compat src
 if ENABLE_DOCS
     SUBDIRS += doc
 endif

--- a/compat/Makefile.am
+++ b/compat/Makefile.am
@@ -1,0 +1,6 @@
+noinst_LTLIBRARIES = compat.la
+
+compat_la_SOURCES = strndup.c
+compat_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+compat_la_LDFLAGS = -module -avoid-version
+compat_la_LIBADD = $(IMUDP_LIBS)

--- a/compat/strndup.c
+++ b/compat/strndup.c
@@ -1,0 +1,40 @@
+/* compatibility file for systems without strndup.
+ *
+ * Copyright 2015 Rainer Gerhards and Adiscon
+ *
+ * This file is part of liblognorm.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "config.h"
+#ifndef HAVE_STRNDUP
+
+#include <stdlib.h>
+#include <string.h>
+char *
+strndup(const char *s, size_t n)
+{
+	const size_t len = strlen(s);
+	if(len <= n)
+		return strdup(s);
+	char *const new_s = malloc(len+1);
+	if(new_s == NULL)
+		return NULL;
+	memcpy(new_s, s, len);
+	new_s[len] = '\0';
+	return new_s;
+}
+
+#endif /* #ifndef HAVE_STRNDUP */

--- a/configure.ac
+++ b/configure.ac
@@ -145,6 +145,7 @@ AC_SUBST(VALGRIND)
 
 AC_CONFIG_FILES([Makefile \
 		lognorm.pc \
+		compat/Makefile \
 		doc/Makefile \
 		src/Makefile \
 		src/lognorm-features.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,7 +9,7 @@ PTHREADS_CFLAGS = -pthread
 bin_PROGRAMS = lognormalizer
 lognormalizer_SOURCES = lognormalizer.c
 lognormalizer_CPPFLAGS =  -I$(top_srcdir) $(JSON_C_CFLAGS) $(LIBESTR_CFLAGS)
-lognormalizer_LDADD = $(JSON_C_LIBS) $(LIBLOGNORM_LIBS) $(LIBESTR_LIBS) 
+lognormalizer_LDADD = $(JSON_C_LIBS) $(LIBLOGNORM_LIBS) $(LIBESTR_LIBS) ../compat/compat.la 
 lognormalizer_DEPENDENCIES = liblognorm.la
 
 check_PROGRAMS = ln_test

--- a/src/liblognorm.h
+++ b/src/liblognorm.h
@@ -251,4 +251,13 @@ int ln_loadSamples(ln_ctx ctx, const char *file);
  */
 int ln_normalize(ln_ctx ctx, const char *str, size_t strLen, struct json_object **json_p);
 
+/* here we add some stuff from the compatibility layer. A separate include
+ * would be cleaner, but would potentially require changes all over the
+ * place. So doing it here is better. The respective replacement
+ * functions should usually be found under ./compat -- rgerhards, 2015-05-20
+ */
+#ifndef HAVE_STRNDUP
+char * strndup(const char *s, size_t n);
+#endif
+
 #endif /* #ifndef LOGNORM_H_INCLUDED */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,7 +7,7 @@ json_eq_LDFLAGS = -no-install
 
 user_test_SOURCES = user_test.c
 user_test_CPPFLAGS = $(LIBLOGNORM_CFLAGS) $(JSON_C_CFLAGS) $(LIBESTR_CFLAGS)
-user_test_LDADD = $(JSON_C_LIBS) $(LIBLOGNORM_LIBS) $(LIBESTR_LIBS)
+user_test_LDADD = $(JSON_C_LIBS) $(LIBLOGNORM_LIBS) $(LIBESTR_LIBS) ../compat/compat.la 
 user_test_LDFLAGS = -no-install
 
 TESTS_SHELLSCRIPTS = \


### PR DESCRIPTION
Fixes build problems in systems who do not have strndup support.
closes https://github.com/rsyslog/liblognorm/issues/100