### PR TITLE
"fix": process last line if it misses the terminating LF

### DIFF
--- a/src/samp.c
+++ b/src/samp.c
@@ -801,7 +801,10 @@ ln_sampRead(ln_ctx ctx, FILE *const __restrict__ repo, int *const __restrict__ i
 		int c = fgetc(repo);
 		if(c == EOF) {
 			*isEof = 1;
-			goto done;
+			if(i == 0)
+				goto done;
+			else
+				done = 1; /* last line missing LF, still process it! */
 		} else if(c == '\n') {
 			++linenbr;
 			if(!inParser && i != 0)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -13,6 +13,7 @@ user_test_LDFLAGS = -no-install
 TESTS_SHELLSCRIPTS = \
 	parser_whitespace.sh \
 	parser_LF.sh \
+	missing_line_ending.sh \
 	field_hexnumber.sh \
 	field_mac48.sh \
 	field_name_value.sh \
@@ -54,6 +55,7 @@ REGEXP_TESTS = \
 	field_regex_while_regex_support_is_disabled.sh
 
 EXTRA_DIST = exec.sh \
+	missing_line_ending.rb \
 	$(TESTS_SHELLSCRIPTS) \
 	$(REGEXP_TESTS) \
 	$(json_eq_self_sources) \

--- a/tests/missing_line_ending.rb
+++ b/tests/missing_line_ending.rb
@@ -1,0 +1,1 @@
+rule=:%field:mac48%

--- a/tests/missing_line_ending.sh
+++ b/tests/missing_line_ending.sh
@@ -3,7 +3,9 @@
 . $srcdir/exec.sh
 
 test_def $0 "dmac48 syntax"
-add_rule 'rule=:%field:mac48%'
+# we need to use a canned file, as we cannot easily reproduce the
+# malformed lines
+cp missing_line_ending.rb $(rulebase_file_name)
 
 execute 'f0:f6:1c:5f:cc:a2'
 assert_output_json_eq '{"field": "f0:f6:1c:5f:cc:a2"}'
@@ -20,4 +22,4 @@ execute 'f0:f6:1c:xf:cc:a2'
 assert_output_json_eq '{ "originalmsg": "f0:f6:1c:xf:cc:a2", "unparsed-data": "f0:f6:1c:xf:cc:a2" }'
 
 
-cleanup_tmp_files
+#cleanup_tmp_files


### PR DESCRIPTION
This problem occurs with the very last line of a rulebase (at EOF).
If it is not properly terminated (LF missing), it is silently ignored.
Previous versions did obviously process lines in this case. While
technically this is invalid input, we can't outrule that such rulebases
exist. For example, they do in the rsyslog testbench, which made
us aware of the problem (see https://github.com/rsyslog/rsyslog/issues/489 ).

I think the proper way of addressing this is to process such lines without
termination, as many other tools do as well.

closes https://github.com/rsyslog/liblognorm/issues/135