### PR TITLE
backport runaway rule check from v2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,11 @@
 ----------------------------------------------------------------------
 Version 1.1.3, 2015-??-??
 - make work on Solaris
+- check for runaway rules.
+  A runaway rule is one that has unmatched percent signs and thus
+  is not terminated properly at its end. This also means we no longer
+  accept "rule=" at the first column of a continuation line, which is
+  no problem (see doc for more information).
 - fix: process last line if it misses the terminating LF
   This problem occurs with the very last line of a rulebase (at EOF).
   If it is not properly terminated (LF missing), it is silently ignored.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -117,6 +117,17 @@ valid, so it could also be written as::
     rule=:%date:date-rfc3164% %host:word% % tag:char-to:\x3a
           %: no longer listening on %  ip:ipv4  %#%  port:number  %'
 
+To prevent a typical user error, continuation lines are **not** permitted
+to start with ``rule=``. There are some obscure cases where this could
+be a valid rule, and it can be re-formatted in that case. Moreoften, this
+is the result of a missing percent sign, as in this sample::
+
+     rule=:test%field:word ... missing percent sign ...
+     rule=:%f:word%
+
+If we would permit ``rule=`` at start of continuation line, these kinds
+of problems would be very hard to detect.
+
 Additional information is dependent on the field type; only some field 
 types need additional information.
     


### PR DESCRIPTION
for v1,
closes  https://github.com/rsyslog/liblognorm/issues/129