### PR TITLE
lognormalizer now handles log-lines bigger than 10k

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,8 @@ test-driver
 test.out
 src/ln_test
 tests/options.sh
+compat/.deps
+compat/.libs
+*.la
+*.lo
+*.o

--- a/src/lognormalizer.c
+++ b/src/lognormalizer.c
@@ -149,13 +149,40 @@ amendLineNbr(json_object *const json, const int line_nbr)
 	}
 }
 
+#define DEFAULT_LINE_SIZE (10 * 1024)
+
+char* read_line(FILE *fp) {
+	size_t line_capacity = DEFAULT_LINE_SIZE;
+	char *line = NULL;
+	size_t line_len = 0;
+	char ch = 0;
+	do {
+		ch = fgetc(fp);
+		if (ch == EOF) break;
+		if (line == NULL) {
+			line = malloc(line_capacity);
+		} else if (line_len == line_capacity) {
+			line_capacity *= 2;
+			line = realloc(line, line_capacity);
+		}
+		line[line_len++] = ch;
+	} while(ch != '\n');
+
+	if (line != NULL) {
+		line[--line_len] = '\0';
+		if(line_len > 0 && line[line_len - 1] == '\r')
+			line[--line_len] = '\0';
+	}
+	return line;
+}
+
 /* normalize input data
  */
 void
 normalize(void)
 {
 	FILE *fp = stdin;
-	char buf[10*1024];
+	char *line = NULL;
 	struct json_object *json = NULL;
 	long long unsigned numParsed = 0;
 	long long unsigned numUnparsed = 0;
@@ -167,13 +194,10 @@ normalize(void)
 		mandatoryTagCstr = es_str2cstr(mandatoryTag, NULL);
 	}
 
-	while((fgets(buf, sizeof(buf), fp)) != NULL) {
+	while((line = read_line(fp)) != NULL) {
 		++line_nbr;
-		buf[strlen(buf)-1] = '\0';
-		if(strlen(buf) > 0 && buf[strlen(buf)-1] == '\r')
-			buf[strlen(buf)-1] = '\0';
-		if(verbose > 0) fprintf(stderr, "To normalize: '%s'\n", buf);
-		ln_normalize(ctx, buf, strlen(buf), &json);
+		if(verbose > 0) fprintf(stderr, "To normalize: '%s'\n", line);
+		ln_normalize(ctx, line, strlen(line), &json);
 		if(json != NULL) {
 			if(eventHasTag(json, mandatoryTagCstr)) {
 				struct json_object *dummy;
@@ -197,6 +221,7 @@ normalize(void)
 			json_object_put(json);
 			json = NULL;
 		}
+        free(line);
 	}
 	if((recOutput & OUTPUT_PARSED_RECS) && numUnparsed > 0)
 		fprintf(stderr, "%llu unparsable entries\n", numUnparsed);

--- a/src/lognormalizer.c
+++ b/src/lognormalizer.c
@@ -165,6 +165,10 @@ char* read_line(FILE *fp) {
 			line_capacity *= 2;
 			line = realloc(line, line_capacity);
 		}
+		if (line == NULL) {
+			fprintf(stderr, "Couldn't allocate working-buffer for log-line\n");
+			return NULL;
+		}
 		line[line_len++] = ch;
 	} while(ch != '\n');
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -75,8 +75,9 @@ TESTS_SHELLSCRIPTS = \
 	field_checkpoint-lea_jsoncnf.sh \
 	field_duration.sh \
 	field_duration_jsoncnf.sh \
-        field_float.sh \ 
-        field_float_jsoncnf.sh
+	field_float.sh \ 
+	field_float_jsoncnf.sh \
+	very_long_logline_jsoncnf.sh
 
 # now come tests for the legacy (v1) engine
 TESTS_SHELLSCRIPTS += \
@@ -96,7 +97,7 @@ TESTS_SHELLSCRIPTS += \
 	field_cef_v1.sh \
 	field_checkpoint-lea_v1.sh \
 	field_duration_v1.sh \
-        field_float_v1.sh \ 
+	field_float_v1.sh \ 
 	field_cee-syslog_v1.sh \
 	field_tokenized.sh \
 	field_tokenized_with_invalid_ruledef.sh \
@@ -109,7 +110,8 @@ TESTS_SHELLSCRIPTS += \
 	field_suffixed.sh \
 	field_suffixed_with_invalid_ruledef.sh \
 	field_cisco-interface-spec.sh \
-	field_float_with_invalid_ruledef.sh
+	field_float_with_invalid_ruledef.sh \
+	very_long_logline.sh
 
 
 #re-add to TESTS if needed: user_test

--- a/tests/very_long_logline.sh
+++ b/tests/very_long_logline.sh
@@ -1,0 +1,16 @@
+# added 2015-09-21 by singh.janmejay
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+msg="foo"
+for i in $(seq 1 10); do
+		msg="${msg},${msg},abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ${i}"
+done
+
+test_def $0 "float field"
+add_rule 'rule=:%line:rest%'
+execute $msg
+assert_output_json_eq "{\"line\": \"$msg\"}"
+
+cleanup_tmp_files
+

--- a/tests/very_long_logline_jsoncnf.sh
+++ b/tests/very_long_logline_jsoncnf.sh
@@ -1,0 +1,17 @@
+# added 2015-09-21 by singh.janmejay
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+
+msg="foo"
+for i in $(seq 1 10); do
+		msg="${msg},${msg},abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ${i}"
+done
+
+test_def $0 "float field"
+add_rule 'version=2'
+add_rule 'rule=:%{"name":"line", "type":"rest"}%'
+execute $msg
+assert_output_json_eq "{\"line\": \"$msg\"}"
+
+cleanup_tmp_files
+


### PR DESCRIPTION
This caused confusion with users trying to parse and seeing it fail and then assuming mmnormalize call will fail too.