### PR TITLE
silence warnings in two categories

### DIFF
--- a/src/pdag.c
+++ b/src/pdag.c
@@ -450,6 +450,8 @@ fixComponentID(struct ln_pdag *const __restrict__ dag, const char *const new)
 	}
 	if(i >= 1 && curr[i-1] == '%')
 		--i;
+	/* don't bother checking success of printf */
+	#pragma GCC diagnostic ignored "-Wunused-result"
 	asprintf(&updated, "%.*s[%s|%s]", i, curr, curr+i, new+i);
 	deleteComponentID(dag);
 	dag->rb_id = updated;
@@ -481,15 +483,21 @@ ln_pdagComponentSetIDs(ln_ctx ctx, struct ln_pdag *const dag, const char *prefix
 		ln_parser_t *prs = dag->parsers+i;
 		if(prs->prsid == PRS_LITERAL) {
 			if(prs->name == NULL) {
+			        /* don't bother checking success of printf */
+			        #pragma GCC diagnostic ignored "-Wunused-result"
 				asprintf(&id, "%s%s", prefix,
 					ln_DataForDisplayLiteral(dag->ctx, prs->parser_data));
 			} else {
+			        /* don't bother checking success of printf */
+			        #pragma GCC diagnostic ignored "-Wunused-result"
 				asprintf(&id, "%s%%%s:%s:%s%%", prefix,
 					prs->name,
 					parserName(prs->prsid),
 					ln_DataForDisplayLiteral(dag->ctx, prs->parser_data));
 			}
 		} else {
+			/* don't bother checking success of printf */
+			#pragma GCC diagnostic ignored "-Wunused-result"
 			asprintf(&id, "%s%%%s:%s%%", prefix,
 				prs->name ? prs->name : "-",
 				parserName(prs->prsid));

--- a/src/samp.c
+++ b/src/samp.c
@@ -947,6 +947,8 @@ ln_sampChkRunawayRule(ln_ctx ctx, FILE *const __restrict__ repo)
 		}
 		if(buf[0] == '\n') {
 			fsetpos(repo, &inner_fpos);
+			/* don't bother checking success of fread */
+			#pragma GCC diagnostic ignored "-Wunused-result"
 			fread(buf, sizeof(char), 1, repo); /* skip '\n' */
 			continue;
 		} else if(buf[0] == '#') {
@@ -1092,6 +1094,8 @@ tryOpenRBFile(ln_ctx ctx, const char *const file)
 	}
 
 	char *fname = NULL;
+	/* don't bother checking success of printf */
+	#pragma GCC diagnostic ignored "-Wunused-result"
 	asprintf(&fname, (rb_lib[strlen(rb_lib)-1] == '/') ? "%s%s" : "%s/%s", rb_lib, file);
 	if((repo = fopen(fname, "r")) == NULL) {
 		const int eno2 = errno;

--- a/src/v1_parser.c
+++ b/src/v1_parser.c
@@ -2008,6 +2008,8 @@ PARSER(CiscoInterfaceSpec)
 	CHKN(*value = json_object_new_object());
 	json_object *json;
 	if(bHaveInterface) {
+		/* idxInterface, lenInterface are set when bHaveIP2 is set to 1 */
+		#pragma GCC diagnostic ignored "-Wuninitialized"
 		CHKN(json = json_object_new_string_len(c+idxInterface, lenInterface));
 		json_object_object_add_ex(*value, "interface", json, JSON_C_OBJECT_ADD_KEY_IS_NEW|JSON_C_OBJECT_KEY_IS_CONSTANT);
 	}
@@ -2016,12 +2018,18 @@ PARSER(CiscoInterfaceSpec)
 	CHKN(json = json_object_new_string_len(c+idxPort, lenPort));
 	json_object_object_add_ex(*value, "port", json, JSON_C_OBJECT_ADD_KEY_IS_NEW|JSON_C_OBJECT_KEY_IS_CONSTANT);
 	if(bHaveIP2) {
+		/* idxIP2, lenIP2 are set when bHaveIP2 is set to 1 */
+		#pragma GCC diagnostic ignored "-Wuninitialized"
 		CHKN(json = json_object_new_string_len(c+idxIP2, lenIP2));
 		json_object_object_add_ex(*value, "ip2", json, JSON_C_OBJECT_ADD_KEY_IS_NEW|JSON_C_OBJECT_KEY_IS_CONSTANT);
+		/* idxPort2 is set when bHaveIP2 is set to 1 */
+		#pragma GCC diagnostic ignored "-Wuninitialized"
 		CHKN(json = json_object_new_string_len(c+idxPort2, lenPort2));
 		json_object_object_add_ex(*value, "port2", json, JSON_C_OBJECT_ADD_KEY_IS_NEW|JSON_C_OBJECT_KEY_IS_CONSTANT);
 	}
 	if(bHaveUser) {
+		/* lenUser, idxUser are set when bHaveUser is set to 1 */
+		#pragma GCC diagnostic ignored "-Wuninitialized"
 		CHKN(json = json_object_new_string_len(c+idxUser, lenUser));
 		json_object_object_add_ex(*value, "user", json, JSON_C_OBJECT_ADD_KEY_IS_NEW|JSON_C_OBJECT_KEY_IS_CONSTANT);
 	}


### PR DESCRIPTION
1. may be uninitialized

  variables that are used after checking a guard variable that's set when they are initialized

2. unused result

  asprintf and fread warnings