### PR TITLE
v1: stop using foreach macros

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ install:
 
 script:
   - autoreconf --force --verbose --install
-  - ./configure --prefix=/opt/liblognorm --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu --mandir=/usr/share/man --infodir=/usr/share/info --datadir=/usr/share --sysconfdir=/etc --localstatedir=/var/lib --disable-dependency-tracking --disable-silent-rules --libdir=/usr/lib64 --enable-debug --enable-testbench --enable-valgrind --enable-regexp --enable-docs
-  - make && make dist && make check && sudo make install
+  - ./configure --prefix=/opt/liblognorm --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu --mandir=/usr/share/man --infodir=/usr/share/info --datadir=/usr/share --sysconfdir=/etc --localstatedir=/var/lib --disable-dependency-tracking --libdir=/usr/lib64 --enable-debug --enable-testbench --enable-valgrind --enable-regexp --enable-docs
+  - make distcheck

--- a/src/enc_syslog.c
+++ b/src/enc_syslog.c
@@ -185,11 +185,15 @@ ln_fmtEventToRFC5424(struct json_object *json, es_str_t **str)
 	if((tags = json_object_object_get(json, "event.tags")) != NULL) {
 		CHKR(ln_addTags_Syslog(tags, str));
 	}
-	json_object_object_foreach(json, name, field) {
+	struct json_object_iterator it = json_object_iter_begin(json);
+	struct json_object_iterator itEnd = json_object_iter_end(json);
+	while (!json_object_iter_equal(&it, &itEnd)) {
+		const char *name = json_object_iter_peek_name(&it);
 		if (strcmp(name, "event.tags")) {
 			es_addChar(str, ' ');
-			ln_addField_Syslog(name, field, str);
+			ln_addField_Syslog(name, json_object_iter_peek_value(&it), str);
 		}
+		json_object_iter_next(&it);
 	}
 	es_addChar(str, ']');
 

--- a/src/enc_xml.c
+++ b/src/enc_xml.c
@@ -206,10 +206,14 @@ ln_fmtEventToXML(struct json_object *json, es_str_t **str)
 	if((tags = json_object_object_get(json, "event.tags")) != NULL) {
 		CHKR(ln_addTags_XML(tags, str));
 	}
-	json_object_object_foreach(json, name, field) {
+	struct json_object_iterator it = json_object_iter_begin(json);
+	struct json_object_iterator itEnd = json_object_iter_end(json);
+	while (!json_object_iter_equal(&it, &itEnd)) {
+		const char *name = json_object_iter_peek_name(&it);
 		if (strcmp(name, "event.tags")) {
-			ln_addField_XML(name, field, str);
+			ln_addField_XML(name, json_object_iter_peek_value(&it), str);
 		}
+		json_object_iter_next(&it);
 	}
 
 	es_addBuf(str, "</event>", 8);

--- a/tests/json_eq.c
+++ b/tests/json_eq.c
@@ -10,13 +10,16 @@ typedef struct json_object obj;
 static int eq(obj* expected, obj* actual);
 
 static int obj_eq(obj* expected, obj* actual) {
-    struct json_object_iter iter;
-    int eql = 1;
-	json_object_object_foreachC(expected, iter) {
-        obj *actual_val = json_object_object_get(actual, iter.key);
-        eql &= eq(iter.val, actual_val);
-    }
-    return eql;
+	struct json_object_iter iter;
+	int eql = 1;
+	struct json_object_iterator it = json_object_iter_begin(expected);
+	struct json_object_iterator itEnd = json_object_iter_end(expected);
+	while (!json_object_iter_equal(&it, &itEnd)) {
+		obj *actual_val = json_object_object_get(actual, json_object_iter_peek_name(&it));
+		eql &= eq(json_object_iter_peek_value(&it), actual_val);
+		json_object_iter_next(&it);
+	}
+	return eql;
 }
 
 static int arr_eq(obj* expected, obj* actual) {

--- a/tests/missing_line_ending.sh
+++ b/tests/missing_line_ending.sh
@@ -5,7 +5,7 @@
 test_def $0 "dmac48 syntax"
 # we need to use a canned file, as we cannot easily reproduce the
 # malformed lines
-cp missing_line_ending.rb $(rulebase_file_name)
+cp $srcdir/missing_line_ending.rb $(rulebase_file_name)
 
 execute 'f0:f6:1c:5f:cc:a2'
 assert_output_json_eq '{"field": "f0:f6:1c:5f:cc:a2"}'


### PR DESCRIPTION
they use internal implementation details; use _iter_ functions instead.
This is also necessary because libfastjson 0.99.3+ will no longer
support the foreach macros.

closes https://github.com/rsyslog/liblognorm/issues/196