### PR TITLE
v2: stop using foreach macros

### DIFF
--- a/src/enc_syslog.c
+++ b/src/enc_syslog.c
@@ -185,11 +185,15 @@ ln_fmtEventToRFC5424(struct json_object *json, es_str_t **str)
 	if(json_object_object_get_ex(json, "event.tags", &tags)) {
 		CHKR(ln_addTags_Syslog(tags, str));
 	}
-	json_object_object_foreach(json, name, field) {
+	struct json_object_iterator it = json_object_iter_begin(json);
+	struct json_object_iterator itEnd = json_object_iter_end(json);
+	while (!json_object_iter_equal(&it, &itEnd)) {
+		char *const name = (char*)json_object_iter_peek_name(&it);
 		if (strcmp(name, "event.tags")) {
 			es_addChar(str, ' ');
-			ln_addField_Syslog(name, field, str);
+			ln_addField_Syslog(name, json_object_iter_peek_value(&it), str);
 		}
+		json_object_iter_next(&it);
 	}
 	es_addChar(str, ']');
 

--- a/src/enc_xml.c
+++ b/src/enc_xml.c
@@ -206,10 +206,14 @@ ln_fmtEventToXML(struct json_object *json, es_str_t **str)
 	if(json_object_object_get_ex(json, "event.tags", &tags)) {
 		CHKR(ln_addTags_XML(tags, str));
 	}
-	json_object_object_foreach(json, name, field) {
+	struct json_object_iterator it = json_object_iter_begin(json);
+	struct json_object_iterator itEnd = json_object_iter_end(json);
+	while (!json_object_iter_equal(&it, &itEnd)) {
+		char *const name = (char*) json_object_iter_peek_name(&it);
 		if (strcmp(name, "event.tags")) {
-			ln_addField_XML(name, field, str);
+			ln_addField_XML(name, json_object_iter_peek_value(&it), str);
 		}
+		json_object_iter_next(&it);
 	}
 
 	es_addBuf(str, "</event>", 8);

--- a/src/parser.c
+++ b/src/parser.c
@@ -609,7 +609,11 @@ PARSER_Construct(HexNumber)
 	if(json == NULL)
 		goto done;
 
-	json_object_object_foreach(json, key, val) {
+	struct json_object_iterator it = json_object_iter_begin(json);
+	struct json_object_iterator itEnd = json_object_iter_end(json);
+	while (!json_object_iter_equal(&it, &itEnd)) {
+		const char *key = json_object_iter_peek_name(&it);
+		struct json_object *const val = json_object_iter_peek_value(&it);
 		if(!strcmp(key, "maxval")) {
 			errno = 0;
 			data->maxval = json_object_get_int64(val);
@@ -621,6 +625,7 @@ PARSER_Construct(HexNumber)
 			ln_errprintf(ctx, 0, "invalid param for hexnumber: %s",
 				 json_object_to_json_string(val));
 		}
+		json_object_iter_next(&it);
 	}
 
 done:
@@ -2590,11 +2595,16 @@ PARSER_Parse(Repeat)
 		 * around.
 		 */
 		struct json_object *toAdd = parsed_value;
-		json_object_object_foreach(parsed_value, key, val) {
+		struct json_object_iterator it = json_object_iter_begin(parsed_value);
+		struct json_object_iterator itEnd = json_object_iter_end(parsed_value);
+		while (!json_object_iter_equal(&it, &itEnd)) {
+			const char *key = json_object_iter_peek_name(&it);
+			struct json_object *const val = json_object_iter_peek_value(&it);
 			if(key[0] == '.' && key[1] == '\0') {
 				json_object_get(val); /* inc refcount! */
 				toAdd = val;
 			}
+			json_object_iter_next(&it);
 		}
 
 		json_object_array_add(json_arr, toAdd);
@@ -2637,7 +2647,11 @@ PARSER_Construct(Repeat)
 	if(json == NULL)
 		goto done;
 
-	json_object_object_foreach(json, key, val) {
+	struct json_object_iterator it = json_object_iter_begin(json);
+	struct json_object_iterator itEnd = json_object_iter_end(json);
+	while (!json_object_iter_equal(&it, &itEnd)) {
+		const char *key = json_object_iter_peek_name(&it);
+		struct json_object *const val = json_object_iter_peek_value(&it);
 		if(!strcmp(key, "parser")) {
 			if(chkNoDupeDotInParserDefs(ctx, val) != 1) {
 				r = LN_BADCONFIG;
@@ -2658,6 +2672,7 @@ PARSER_Construct(Repeat)
 			ln_errprintf(ctx, 0, "invalid param for hexnumber: %s",
 				 json_object_to_json_string(val));
 		}
+		json_object_iter_next(&it);
 	}
 
 done:
@@ -2749,7 +2764,11 @@ stringAddPermittedCharsViaArray(ln_ctx ctx, struct data_String *const data,
 	for(int i = 0 ; i < nelem ; ++i) {
 		struct json_object *const elem
 			= json_object_array_get_idx(arr, i);
-		json_object_object_foreach(elem, key, val) {
+		struct json_object_iterator it = json_object_iter_begin(elem);
+		struct json_object_iterator itEnd = json_object_iter_end(elem);
+		while (!json_object_iter_equal(&it, &itEnd)) {
+			const char *key = json_object_iter_peek_name(&it);
+			struct json_object *const val = json_object_iter_peek_value(&it);
 			if(!strcasecmp(key, "chars")) {
 				stringAddPermittedChars(data, val);
 			} else if(!strcasecmp(key, "class")) {
@@ -2770,6 +2789,7 @@ stringAddPermittedCharsViaArray(ln_ctx ctx, struct data_String *const data,
 						optval);
 				}
 			}
+		json_object_iter_next(&it);
 		}
 	}
 }
@@ -2902,7 +2922,11 @@ PARSER_Construct(String)
 	data->qchar_end = '"';
 	memset(data->perm_chars, 0xff, sizeof(data->perm_chars));
 	
-	json_object_object_foreach(json, key, val) {
+	struct json_object_iterator it = json_object_iter_begin(json);
+	struct json_object_iterator itEnd = json_object_iter_end(json);
+	while (!json_object_iter_equal(&it, &itEnd)) {
+		const char *key = json_object_iter_peek_name(&it);
+		struct json_object *const val = json_object_iter_peek_value(&it);
 		if(!strcasecmp(key, "quoting.mode")) {
 			const char *const optval = json_object_get_string(val);
 			if(!strcasecmp(optval, "auto")) {
@@ -2966,6 +2990,7 @@ PARSER_Construct(String)
 			ln_errprintf(ctx, 0, "invalid param for hexnumber: %s",
 				 json_object_to_json_string(val));
 		}
+		json_object_iter_next(&it);
 	}
 
 	if(data->quoteMode == ST_QUOTE_NONE)

--- a/src/pdag.c
+++ b/src/pdag.c
@@ -1322,9 +1322,13 @@ fixJSON(struct ln_pdag *dag,
 		}
 	} else if(prs->name != NULL && prs->name[0] == '.' && prs->name[1] == '\0') {
 		if(json_object_get_type(*value) == json_type_object) {
-			json_object_object_foreach(*value, key, val) {
+			struct json_object_iterator it = json_object_iter_begin(*value);
+			struct json_object_iterator itEnd = json_object_iter_end(*value);
+			while (!json_object_iter_equal(&it, &itEnd)) {
+				struct json_object *const val = json_object_iter_peek_value(&it); 
 				json_object_get(val);
-				json_object_object_add(json, key, val);
+				json_object_object_add(json, json_object_iter_peek_name(&it), val);
+				json_object_iter_next(&it);
 			}
 			json_object_put(*value);
 		} else {

--- a/src/samp.c
+++ b/src/samp.c
@@ -182,9 +182,13 @@ ln_parseLegacyFieldDescr(ln_ctx ctx,
 	}
 	if(json != NULL) {
 		/* now we need to merge the json params into the main object */
-		json_object_object_foreach(json, key, v) {
+		struct json_object_iterator it = json_object_iter_begin(json);
+		struct json_object_iterator itEnd = json_object_iter_end(json);
+		while (!json_object_iter_equal(&it, &itEnd)) {
+			struct json_object *const v = json_object_iter_peek_value(&it);
 			json_object_get(v);
-			json_object_object_add(*prscnf, key, v);
+			json_object_object_add(*prscnf, json_object_iter_peek_name(&it), v);
+			json_object_iter_next(&it);
 		}
 	}
 

--- a/tests/json_eq.c
+++ b/tests/json_eq.c
@@ -10,14 +10,15 @@ typedef struct json_object obj;
 static int eq(obj* expected, obj* actual);
 
 static int obj_eq(obj* expected, obj* actual) {
-    struct json_object_iter iter;
-    int eql = 1;
-	json_object_object_foreachC(expected, iter) {
-        obj *actual_val;
-        json_object_object_get_ex(actual, iter.key, &actual_val);
-        eql &= eq(iter.val, actual_val);
-    }
-    return eql;
+	int eql = 1;
+	struct json_object_iterator it = json_object_iter_begin(expected);
+	struct json_object_iterator itEnd = json_object_iter_end(expected);
+	while (!json_object_iter_equal(&it, &itEnd)) {
+		obj *actual_val = json_object_object_get(actual, json_object_iter_peek_name(&it));
+		eql &= eq(json_object_iter_peek_value(&it), actual_val);
+		json_object_iter_next(&it);
+	}
+	return eql;
 }
 
 static int arr_eq(obj* expected, obj* actual) {


### PR DESCRIPTION
they use internal implementation details; use _iter_ functions instead.
This is also necessary because libfastjson 0.99.3+ will no longer
support the foreach macros.

closes https://github.com/rsyslog/liblognorm/issues/197