### PR TITLE
Do not define strndup() as part of the public API

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -95,4 +95,9 @@ const char * ln_DataForDisplayCharTo(__attribute__((unused)) ln_ctx ctx, void *c
 const char * ln_DataForDisplayLiteral(__attribute__((unused)) ln_ctx ctx, void *const pdata);
 const char * ln_JsonConfLiteral(__attribute__((unused)) ln_ctx ctx, void *const pdata);
 
+/* here we add some stuff from the compatibility layer */
+#ifndef HAVE_STRNDUP
+char * strndup(const char *s, size_t n);
+#endif
+
 #endif /* #ifndef INTERNAL_H_INCLUDED */

--- a/src/liblognorm.h
+++ b/src/liblognorm.h
@@ -253,13 +253,4 @@ int ln_loadSamples(ln_ctx ctx, const char *file);
  */
 int ln_normalize(ln_ctx ctx, const char *str, const size_t strLen, struct json_object **json_p);
 
-/* here we add some stuff from the compatibility layer. A separate include
- * would be cleaner, but would potentially require changes all over the
- * place. So doing it here is better. The respective replacement
- * functions should usually be found under ./compat -- rgerhards, 2015-05-20
- */
-#ifndef HAVE_STRNDUP
-char * strndup(const char *s, size_t n);
-#endif
-
 #endif /* #ifndef LOGNORM_H_INCLUDED */


### PR DESCRIPTION
This function is only used internally, so define it in internal.h.
Making it public breaks code which tries to build against liblognorm.h
due to conflicting definitions of strndup().

Since we already have an internal header file, just add the compat definitions there instead of creating a separate header file.
See #214 