### PR TITLE
fix misleading indentation warnings with GCC6

### DIFF
--- a/src/v1_samp.c
+++ b/src/v1_samp.c
@@ -758,11 +758,11 @@ struct ln_v1_samp *
 ln_v1_processSamp(ln_ctx ctx, const char *buf, es_size_t lenBuf)
 {
 	struct ln_v1_samp *samp = NULL;
-    es_str_t *typeStr = NULL;
-    es_size_t offs;
+	es_str_t *typeStr = NULL;
+	es_size_t offs;
 
-    if(getLineType(buf, lenBuf, &offs, &typeStr) != 0)
-        goto done;
+	if(getLineType(buf, lenBuf, &offs, &typeStr) != 0)
+		goto done;
 
 	if(!es_strconstcmp(typeStr, "prefix")) {
 		if(getPrefix(buf, lenBuf, offs, &ctx->rulePrefix) != 0) goto done;


### PR DESCRIPTION
v1_samp.c had mixed tabs and spaces indentation which GCC 6 complains
about:

v1_samp.c: In function 'ln_v1_processSamp':
v1_samp.c:764:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
     if(getLineType(buf, lenBuf, &offs, &typeStr) != 0)
     ^~
v1_samp.c:767:2: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
  if(!es_strconstcmp(typeStr, "prefix")) {
  ^~

Fix by using tabs consistently in that function.