### PR TITLE
Type fixes

### DIFF
--- a/src/lognormalizer.c
+++ b/src/lognormalizer.c
@@ -179,7 +179,7 @@ read_line(FILE *fp)
 	size_t line_capacity = DEFAULT_LINE_SIZE;
 	char *line = NULL;
 	size_t line_len = 0;
-	char ch = 0;
+	int ch = 0;
 	do {
 		ch = fgetc(fp);
 		if (ch == EOF) break;

--- a/src/parser.c
+++ b/src/parser.c
@@ -161,7 +161,7 @@ PARSER_Parse(RFC5424Date)
 	int second;
 	__attribute__((unused)) int secfrac;	/* fractional seconds (must be 32 bit!) */
 	__attribute__((unused)) int secfracPrecision;
-	char OffsetHour;	/* UTC offset in hours */
+	int OffsetHour;		/* UTC offset in hours */
 	int OffsetMinute;	/* UTC offset in minutes */
 	size_t len;
 	size_t orglen;

--- a/src/v1_parser.c
+++ b/src/v1_parser.c
@@ -200,7 +200,7 @@ PARSER(RFC5424Date)
 	int second;
 	__attribute__((unused)) int secfrac;	/* fractional seconds (must be 32 bit!) */
 	__attribute__((unused)) int secfracPrecision;
-	char OffsetHour;	/* UTC offset in hours */
+	int OffsetHour;		/* UTC offset in hours */
 	int OffsetMinute;	/* UTC offset in minutes */
 	size_t len;
 	size_t orglen;


### PR DESCRIPTION
Use type int instead of char in various places to fix GCC warning:
```
warning: comparison is always false due to limited range of data type [-Wtype-limits]
```
In case of lognormalizer using the incorrect type lead to a never finishing loop in read_line()