### PR TITLE
Use Libs.private instead of Requires.private in pkgconfig

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,8 @@ AC_SUBST(LIBLOGNORM_LIBS)
 # modules we require
 PKG_CHECK_MODULES(LIBESTR, libestr >= 0.0.0)
 PKG_CHECK_MODULES(JSON_C, libfastjson,, )
+# add libestr flags to pkgconfig file for static linking
+AC_SUBST(pkg_config_libs_private, $LIBESTR_LIBS)
 
 # Regular expressions
 AC_ARG_ENABLE(regexp,

--- a/lognorm.pc.in
+++ b/lognorm.pc.in
@@ -7,6 +7,6 @@ Name: lognorm
 Description: fast samples-based log normalization library
 Version: @VERSION@
 Requires: libfastjson
-Requires.private: libestr
 Libs: -L${libdir} -llognorm
+Libs.private: @pkg_config_libs_private@
 Cflags: -I${includedir}


### PR DESCRIPTION
Requires.private has an unfortunate side effect: when pkg-config
--cflags is called, if the pkg-config of a Requires.private library
is not available, it will fail. This is very counter-intuitive, as
one would expect Requires.private to be parsed only if pkg-config is
called with --static, but that's the case only for --libs, not
--cflags.

Autogenerate Libs.private from libestr pkg-config --libs output via
autoconf.

Without libestr-dev installed (no libestr.pc):

```
$ PKG_CONFIG_PATH=./ pkg-config --static --libs lognorm
-L/usr/local/lib -llognorm -lestr -lfastjson 
$ PKG_CONFIG_PATH=./ pkg-config --libs lognorm
-L/usr/local/lib -llognorm -lfastjson 
$ PKG_CONFIG_PATH=./ pkg-config --cflags lognorm
-I/usr/local/include -I/usr/include/libfastjson 
```
