### PR TITLE
bugfix: no error message emitted for invalid "annotate" operation

### DIFF
--- a/src/annot.c
+++ b/src/annot.c
@@ -220,7 +220,7 @@ ln_annotate(ln_ctx ctx, struct json_object *json, struct json_object *tagbucket)
 	const char *tagCstr;
 	int i;
 
-	ln_dbgprintf(ctx, "ln_annotate called");
+	ln_dbgprintf(ctx, "ln_annotate called [aroot=%p]", ctx->pas->aroot);
 	/* shortcut: terminate immediately if nothing to do... */
 	if(ctx->pas->aroot == NULL)
 		goto done;

--- a/src/samp.c
+++ b/src/samp.c
@@ -739,13 +739,14 @@ getAnnotationOp(ln_ctx ctx, ln_annot *annot, const char *buf, es_size_t lenBuf, 
 		goto done; /* nothing left to process (no error!) */
 	}
 
-	if(buf[i] == '+') {
+	switch(buf[i]) {
+	case '+':
 		opc = ln_annot_ADD;
-	} else if(buf[i] == '-') {
+		break;
+	case '-':
 		ln_dbgprintf(ctx, "annotate op '-' not yet implemented - failing");
-		goto fail;
-	} else {
-		ln_dbgprintf(ctx, "invalid annotate opcode '%c' - failing" , buf[i]);
+		/*FALLTHROUGH*/
+	default:ln_errprintf(ctx, 0, "invalid annotate operation '%c': %s", buf[i], buf+i);
 		goto fail;
 	}
 	i++;


### PR DESCRIPTION
closes https://github.com/rsyslog/liblognorm/issues/224

