### PR TITLE
parseNameValue: fix no quoting support

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1967,10 +1967,22 @@ parseNameValue(npb_t *const npb,
 	const size_t lenName = i - iName;
 	++i; /* skip '=' */
 
+	char quoting = npb->str[i]; // end of string
+	if (i < npb->strLen && (quoting == '"' || quoting == '\''))
+		++i;
+	else
+		quoting = 0; // str[i] can't be null, is a good default value
+
 	const size_t iVal = i;
-	while(i < npb->strLen && !isspace(npb->str[i]))
+	while(i < npb->strLen &&
+	     ((quoting && npb->str[i] != quoting) || (!quoting && !isspace(npb->str[i]))))
 		++i;
 	const size_t lenVal = i - iVal;
+
+	if (i < npb->strLen && npb->str[i] == quoting)
+		++i;
+	else if (quoting)
+		goto done;
 
 	/* parsing OK */
 	*offs = i;


### PR DESCRIPTION
Function description announce support of quoted variable :
- name=value
- name="value"
- name='value'

... but there is nothing in the code to really support quoted string.
I had small fixes to support it.

My tests :
$ cat > test.txt <<EOF
a=
a=123
a=123
a='123'
a="123"
a=123 b=456
a=123 b="456"
a=123 b="456" c=
a=123 b="456'789" c=
a=123 b="456 789" c=
a=123 b="456 789' c=
a=123 b=456 789 c=
EOF

$ cat > test.rb << EOF
version=2
rule=test-ok:%[
  {"type": "name-value-list"}
  ]%
EOF

$ cat test.txt | ./lognormalizer -r test.rb -T
{ "event.tags": [ "test-ok" ] }
{ "event.tags": [ "test-ok" ] }
{ "event.tags": [ "test-ok" ] }
{ "event.tags": [ "test-ok" ] }
{ "event.tags": [ "test-ok" ] }
{ "event.tags": [ "test-ok" ] }
{ "event.tags": [ "test-ok" ] }
{ "event.tags": [ "test-ok" ] }
{ "event.tags": [ "test-ok" ] }
{ "event.tags": [ "test-ok" ] }
{ "originalmsg": "a=123 b=\"456 789' c= ", "unparsed-data": "a=123 b=\"456 789' c= " }
{ "originalmsg": "a=123 b=456 789 c= ", "unparsed-data": "a=123 b=456 789 c= " }