### PR TITLE
bugfix: literal parser does not always store value if name is specified

### DIFF
--- a/src/pdag.c
+++ b/src/pdag.c
@@ -352,7 +352,10 @@ optLitPathCompact(ln_ctx ctx, ln_parser_t *prs)
 		     && prs->node->flags.isTerminal == 0
 		     && prs->node->refcnt == 1
 		     && prs->node->nparsers == 1
-		     && prs->node->parsers[0].prsid == PRS_LITERAL)
+		     /* we need to do some checks on the child as well */
+		     && prs->node->parsers[0].prsid == PRS_LITERAL
+		     && prs->node->parsers[0].name == NULL
+		     && prs->node->parsers[0].node->refcnt == 1)
 		  )
 			goto done;
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -35,6 +35,7 @@ TESTS_SHELLSCRIPTS = \
 	usrdef_ipaddr_dotdot3.sh \
 	missing_line_ending.sh \
 	names.sh \
+	literal.sh \
 	include.sh \
 	include_RULEBASES.sh \
 	seq_simple.sh \

--- a/tests/literal.sh
+++ b/tests/literal.sh
@@ -1,0 +1,30 @@
+# added 2016-12-21 by Rainer Gerhards
+# This file is part of the liblognorm project, released under ASL 2.0
+
+. $srcdir/exec.sh
+test_def $0 "using names with literal"
+
+add_rule 'version=2'
+add_rule 'rule=:%{"type":"literal", "text":"a", "name":"var"}%'
+execute 'a'
+assert_output_json_eq '{ "var": "a" }'
+
+reset_rules
+add_rule 'version=2'
+add_rule 'rule=:Test %{"type":"literal", "text":"a", "name":"var"}%'
+execute 'Test a'
+assert_output_json_eq '{ "var": "a" }'
+
+reset_rules
+add_rule 'version=2'
+add_rule 'rule=:Test %{"type":"literal", "text":"a", "name":"var"}% End'
+execute 'Test a End'
+assert_output_json_eq '{ "var": "a" }'
+
+reset_rules
+add_rule 'version=2'
+add_rule 'rule=:a %[{"name":"num", "type":"number"}, {"name":"colon", "type":"literal", "text":":"}, {"name":"hex", "type":"hexnumber"}]% b'
+execute 'a 4711:0x4712 b'
+assert_output_json_eq '{ "hex": "0x4712", "colon": ":", "num": "4711" }'
+
+cleanup_tmp_files


### PR DESCRIPTION
if
rule=:%{"type":"literal", "text":"a", "name":"var"}%
is used and matching message is provided, variable var ist not persisted.

see also http://lists.adiscon.net/pipermail/rsyslog/2016-December/043985.html