### PR TITLE
bugfix: string parser mishandling strings at the end of rules

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -2866,7 +2866,7 @@ PARSER_Parse(String)
 		goto done;
 
 	const size_t trmChkIdx = (bHaveQuotes) ? i+1 : i;
-	if(npb->str[trmChkIdx] != ' ')
+	if(npb->str[trmChkIdx] != ' ' && trmChkIdx != npb->strLen)
 		goto done;
 
 	/* success, persist */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -68,6 +68,7 @@ TESTS_SHELLSCRIPTS = \
 	field_hexnumber_jsoncnf.sh \
 	field_hexnumber_range.sh \
 	field_hexnumber_range_jsoncnf.sh \
+	rule_last_str_short.sh \
 	field_mac48.sh \
 	field_mac48_jsoncnf.sh \
 	field_name_value.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -75,6 +75,7 @@ TESTS_SHELLSCRIPTS = \
 	field_kernel_timestamp.sh \
 	field_kernel_timestamp_jsoncnf.sh \
 	field_whitespace.sh \
+	rule_last_str_long.sh \
 	field_whitespace_jsoncnf.sh \
 	field_rest.sh \
 	field_rest_jsoncnf.sh \

--- a/tests/rule_last_str_long.sh
+++ b/tests/rule_last_str_long.sh
@@ -1,0 +1,19 @@
+. $srcdir/exec.sh
+
+test_def $0 "multiple formats including string (see also: rule_last_str_short.sh)"
+add_rule 'version=2'
+add_rule 'rule=:%string:string%'
+add_rule 'rule=:before %string:string%'
+add_rule 'rule=:%string:string% after'
+add_rule 'rule=:before %string:string% after'
+add_rule 'rule=:before %string:string% middle %string:string%'
+
+execute 'string'
+execute 'before string'
+execute 'string after'
+execute 'before string after'
+execute 'before string middle string'
+assert_output_json_eq '{"string": "string" }' '{"string": "string" }''{"string": "string" }''{"string": "string" }''{"string": "string", "string": "string" }'
+
+
+cleanup_tmp_files

--- a/tests/rule_last_str_short.sh
+++ b/tests/rule_last_str_short.sh
@@ -1,0 +1,13 @@
+. $srcdir/exec.sh
+
+test_def $0 "string being last in a rule (see also: rule_last_str_long.sh)"
+
+add_rule 'version=2'
+add_rule 'rule=:%string:string%'
+
+execute 'string'
+
+assert_output_json_eq '{"string": "string" }'
+
+
+cleanup_tmp_files


### PR DESCRIPTION
string parser will fail if it is the last thing on a line.

closes https://github.com/rsyslog/liblognorm/issues/207