### PR TITLE
compatibility layer had an unclean function definition

### DIFF
--- a/compat/strndup.c
+++ b/compat/strndup.c
@@ -37,8 +37,8 @@ strndup(const char *s, size_t n)
 	return new_s;
 }
 #else /* #ifndef HAVE_STRNDUP */
-/* Solaris must have at least one symbol inside a file, so we provide
- * it here ;-)
+/* this just ensures that we have at least one symbol in our lib.
+ * Otherwise, we have a build failure under Solaris.
  */
 void dummy_dummy_required_for_solaris_do_not_use(void)
 {


### PR DESCRIPTION
which triggerred build errors/warnings on some platforms
We could correct this with detection for Solaris, but for that we
would need to change our autoconf configuration, for what I
currently have no time. So I just correct the invalid type.
This causes no harm except for maybe some bytes of unnecessary
object code. Comment now describes the use case.

Thanks to Andreas Stieger for bringing this up.

see also https://github.com/rsyslog/liblognorm/pull/265#issuecomment-344266023