### PR TITLE
parser/rfc5424-date: allow to terminate on any non-alnum character

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -404,7 +404,9 @@ PARSER_Parse(RFC5424Date)
 	}
 
 	if(len > 0) {
-		if(*pszTS != ' ') /* if it is not a space, it can not be a "good" time */
+		/* if it is alpha or number, it can not be a "good" time
+		 * a successful match terminates on space, tab, comma, ... */
+		if(isalnum(*pszTS))
 			goto done;
 	}
 


### PR DESCRIPTION
Terminating on a space was too restrictive. The patch allow the
match to terminate on any non-alnum character, thus allowing space,
tab, comma, ...