### PR TITLE
Correct CLI options in the docs

### DIFF
--- a/doc/lognormalizer.rst
+++ b/doc/lognormalizer.rst
@@ -11,7 +11,7 @@ or write files.
 
 An example of the command::
 
-    $ lognormalizer -r messages.sampdb -o json <messages.log
+    $ lognormalizer -r messages.sampdb -e json <messages.log
 
 Command line options
 --------------------


### PR DESCRIPTION
This corrects the output CLI option from `-o` (which is for something else) to `-e` in the documentation.