### PR TITLE
Fix for use after free (issue #235)

### DIFF
--- a/src/pdag.c
+++ b/src/pdag.c
@@ -267,7 +267,7 @@ ln_newParser(ln_ctx ctx,
 	node->prsid = prsid;
 	node->conf = strdup(textconf);
 	if(prsid == PRS_CUSTOM_TYPE) {
-		node->custType = custType;
+		node->custTypeIdx = custType - ctx->type_pdags;
 	} else {
 		if(parser_lookup_table[prsid].construct != NULL) {
 			parser_lookup_table[prsid].construct(ctx, prscnf, &node->parser_data);
@@ -1437,10 +1437,10 @@ tryParser(npb_t *const __restrict__ npb,
 	if(prs->prsid == PRS_CUSTOM_TYPE) {
 		if(*value == NULL)
 			*value = json_object_new_object();
-		LN_DBGPRINTF(dag->ctx, "calling custom parser '%s'", prs->custType->name);
-		r = ln_normalizeRec(npb, prs->custType->pdag, *offs, 1, *value, &endNode);
+		LN_DBGPRINTF(dag->ctx, "calling custom parser '%s'", dag->ctx->type_pdags[prs->custTypeIdx].name);
+		r = ln_normalizeRec(npb, dag->ctx->type_pdags[prs->custTypeIdx].pdag, *offs, 1, *value, &endNode);
 		LN_DBGPRINTF(dag->ctx, "called CUSTOM PARSER '%s', result %d, "
-			"offs %zd, *pParsed %zd", prs->custType->name, r, *offs, *pParsed);
+			"offs %zd, *pParsed %zd", dag->ctx->type_pdags[prs->custTypeIdx].name, r, *offs, *pParsed);
 		*pParsed = npb->parsedTo - *offs;
 		#ifdef	ADVANCED_STATS
 		es_addBuf(&npb->astats.exec_path, hdr, lenhdr);

--- a/src/pdag.h
+++ b/src/pdag.h
@@ -82,7 +82,7 @@ struct ln_parser_s {
 	prsid_t prsid;		/**< parser ID (for lookup table) */
 	ln_pdag *node;		/**< node to branch to if parser succeeded */
 	void *parser_data;	/**< opaque data that the field-parser understands */
-	struct ln_type_pdag *custType;	/**< points to custom type, if such is used */
+	size_t custTypeIdx;	/**< index to custom type, if such is used */
 	int prio;		/**< priority (combination of user- and parser-specific parts) */
 	const char *name;	/**< field name */
 	const char *conf;	/**< configuration as printable json for comparison reasons */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -33,6 +33,7 @@ TESTS_SHELLSCRIPTS = \
 	usrdef_ipaddr_dotdot.sh \
 	usrdef_ipaddr_dotdot2.sh \
 	usrdef_ipaddr_dotdot3.sh \
+	usrdef_nested_segfault.sh \
 	missing_line_ending.sh \
 	lognormalizer-invld-call.sh \
 	string_rb_simple.sh \

--- a/tests/usrdef_nested_segfault.sh
+++ b/tests/usrdef_nested_segfault.sh
@@ -1,0 +1,17 @@
+# added 2018-04-07 by Vincent Tondellier
+# based on usrdef_twotypes.sh
+# This file is part of the liblognorm project, released under ASL 2.0
+
+. $srcdir/exec.sh
+
+test_def $0 "nested user-defined types"
+add_rule 'version=2'
+add_rule 'type=@hex-byte:%..:hexnumber{"maxval": "255"}%'
+add_rule 'type=@two-hex-bytes:%f1:@hex-byte% %f2:@hex-byte%'
+add_rule 'type=@unused:stop'
+add_rule 'rule=:two bytes %.:@two-hex-bytes% %-:@unused%'
+
+execute 'two bytes 0xff 0x16 stop'
+assert_output_json_eq '{ "f1": "0xff", "f2": "0x16" }'
+
+cleanup_tmp_files


### PR DESCRIPTION
The problem occurs when a user type references another user type : a pointer to the first type is stored in the second, but the array is realloc-ed when you add a third user type, and the pointer becomes invalid.
See issue for more details

1st commit for the test case
2nd will be the fix: use an index instead of a pointer