### PR TITLE
build system: fix gcc warning

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -31,7 +31,7 @@
  *//*
  *
  * liblognorm - a fast samples-based log normalization library
- * Copyright 2010-2016 by Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2010-2018 by Rainer Gerhards and Adiscon GmbH.
  *
  * Modified by Pavel Levshin (pavel@levshin.spb.ru) in 2013
  *
@@ -55,6 +55,12 @@
  */
 #ifndef INTERNAL_H_INCLUDED
 #define	INTERNAL_H_INCLUDED
+
+/* the jump-misses-init gcc warning is overdoing when we jump to the
+ * exit of a function to get proper finalization. So let's disable it.
+ * rgerhards, 2018-04-25
+ */
+#pragma GCC diagnostic ignored "-Wjump-misses-init"
 
 #include "liblognorm.h"
 

--- a/src/samp.c
+++ b/src/samp.c
@@ -2,7 +2,7 @@
  * This code handles rulebase processing. Rulebases have been called
  * "sample bases" in the early days of liblognorm, thus the name.
  *
- * Copyright 2010-2015 by Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2010-2018 by Rainer Gerhards and Adiscon GmbH.
  *
  * Modified by Pavel Levshin (pavel@levshin.spb.ru) in 2013
  *
@@ -41,7 +41,6 @@
 #include "pdag.h"
 #include "v1_liblognorm.h"
 #include "v1_ptree.h"
-
 
 void
 ln_sampFree(ln_ctx __attribute__((unused)) ctx, struct ln_samp *samp)


### PR DESCRIPTION
The jump-misses-init gcc warning is overdoing when we jump to the
exit of a function to get proper finalization. So let's disable it.

This also fixes our Travis CI builds.