### PR TITLE
Fix for #229 (cisco-interface-spec at end of line)

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1794,7 +1794,6 @@ PARSER_Parse(CiscoInterfaceSpec)
 	size_t lenPort;
 	if(ln_v2_parseNumber(npb, &i, NULL, &lenPort, NULL) != 0) goto done;
 	i += lenPort;
-	if(i == npb->strLen) goto success;
 
 	/* check if optional second ip/port is present
 	 * We assume we must at least have 5 chars [" (::1)"]


### PR DESCRIPTION
This is a fix for #229 as the parser was exiting too early if there is no space at the end and would not save the parsed data. Did some tests with samples I had and ran it with valgrind but maybe someone can test it too?