### PR TITLE
fix very theoretic misadressing (gcc-8 warning)

### DIFF
--- a/src/lognorm.c
+++ b/src/lognorm.c
@@ -115,7 +115,7 @@ ln_errprintf(const ln_ctx ctx, const int eno, const char *fmt, ...)
 	}
 
 	if(eno != 0) {
-		rs_strerror_r(eno, errbuf, sizeof(errbuf));
+		rs_strerror_r(eno, errbuf, sizeof(errbuf)-1);
 		lenBuf = snprintf(finalbuf, sizeof(finalbuf), "%s: %s", buf, errbuf);
 		msg = finalbuf;
 	} else {


### PR DESCRIPTION
This should not happen due to the shortness of OS error
messages. Nevertheless, it does not hurt doing it right ;-)