### PR TITLE
fix memory leak when a custom type in rules does not match

### DIFF
--- a/src/pdag.c
+++ b/src/pdag.c
@@ -1442,6 +1442,10 @@ tryParser(npb_t *const __restrict__ npb,
 		LN_DBGPRINTF(dag->ctx, "called CUSTOM PARSER '%s', result %d, "
 			"offs %zd, *pParsed %zd", dag->ctx->type_pdags[prs->custTypeIdx].name, r, *offs, *pParsed);
 		*pParsed = npb->parsedTo - *offs;
+		if (r != 0) {
+			json_object_put(*value);
+			*value = NULL;
+		}
 		#ifdef	ADVANCED_STATS
 		es_addBuf(&npb->astats.exec_path, hdr, lenhdr);
 		es_addBuf(&npb->astats.exec_path, "[R:USR],", 8);


### PR DESCRIPTION
this patch fixes memory leak on my setup, might be related to https://github.com/rsyslog/rsyslog/issues/3779, I have a similar setup. I don't even know if this right fix but it is working for me.