### PR TITLE
Fix build problem with travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ matrix:
 before_install:
   - travis_retry sudo apt-get update -qq
   - travis_retry sudo apt-get install -qq libpcre3-dev libpcre3-dbg valgrind python-pip
+  - travis_retry sudo add-apt-repository ppa:adiscon/v8-stable -y
   - travis_retry sudo apt-get install -qq libestr-dev libfastjson-dev
   - travis_retry sudo apt-get install -qq clang
   - travis_retry sudo pip install -U sphinx
-  - travis_retry sudo add-apt-repository ppa:adiscon/v8-stable -y
   - travis_retry sudo apt-get update -qq
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,23 +24,23 @@ matrix:
          dist: trusty
 
 before_install:
-- travis_retry sudo apt-get update -qq
-- travis_retry sudo apt-get install -qq libpcre3-dev libpcre3-dbg valgrind python-pip
-- travis_retry sudo apt-get install -qq libestr-dev libfastjson-dev
-- travis_retry sudo apt-get install -qq clang
-- travis_retry sudo pip install -U sphinx
-- travis_retry sudo add-apt-repository ppa:adiscon/v8-stable -y
-- travis_retry sudo apt-get update -qq
+  - travis_retry sudo apt-get update -qq
+  - travis_retry sudo apt-get install -qq libpcre3-dev libpcre3-dbg valgrind python-pip
+  - travis_retry sudo apt-get install -qq libestr-dev libfastjson-dev
+  - travis_retry sudo apt-get install -qq clang
+  - travis_retry sudo pip install -U sphinx
+  - travis_retry sudo add-apt-repository ppa:adiscon/v8-stable -y
+  - travis_retry sudo apt-get update -qq
 
 install:
 # the following is a work-around to solve the
 # "too old autoconf-archive" problem
-- mkdir tmp
-- cd tmp
-- git clone git://git.sv.gnu.org/autoconf-archive.git
-- sudo cp autoconf-archive/m4/* /usr/share/aclocal
-- cd ..
-- rm -rf tmp
+  - mkdir tmp
+  - cd tmp
+  - git clone git://git.sv.gnu.org/autoconf-archive.git
+  - sudo cp autoconf-archive/m4/* /usr/share/aclocal
+  - cd ..
+  - rm -rf tmp
 
 script:
   - CI/check_codestyle.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
 
 install:
   - travis_retry sudo apt-get install -y libpcre3-dev libpcre3-dbg valgrind python-pip
-  - travis_retry sudo apt-get install -y libestr-devel libfastjson-devel
+  - travis_retry sudo apt-get install -y libestr libestr-dev libfastjson-dev
 # the following is a work-around to solve the
 # "too old autoconf-archive" problem
   - mkdir tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,15 @@ matrix:
          dist: trusty
 
 before_install:
-  - travis_retry sudo apt-get update -qq
-  - travis_retry sudo apt-get install -qq libpcre3-dev libpcre3-dbg valgrind python-pip
-  - travis_retry sudo add-apt-repository ppa:adiscon/v8-stable -y
-  - travis_retry sudo apt-get install -qq libestr-dev libfastjson-dev
-  - travis_retry sudo apt-get install -qq clang
+  - travis_retry sudo add-apt-repository -y ppa:adiscon/v8-stable
+  - travis_retry sudo apt-get install -y clang
   - travis_retry sudo pip install -U sphinx
-  - travis_retry sudo apt-get update -qq
+  - travis_retry sudo apt-get update
 
 install:
+  - set -x
+  - travis_retry sudo apt-get install -y libpcre3-dev libpcre3-dbg valgrind python-pip
+  - travis_retry sudo apt-get install -y libestr-dev libfastjson-dev
 # the following is a work-around to solve the
 # "too old autoconf-archive" problem
   - mkdir tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,8 @@ before_install:
   - travis_retry sudo apt-get update
 
 install:
-  - set -x
   - travis_retry sudo apt-get install -y libpcre3-dev libpcre3-dbg valgrind python-pip
-  - travis_retry sudo apt-get install -y libestr-dev libfastjson-dev
+  - travis_retry sudo apt-get install -y libestr-devel libfastjson-devel
 # the following is a work-around to solve the
 # "too old autoconf-archive" problem
   - mkdir tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ before_install:
 
 install:
   - travis_retry sudo apt-get install -y libpcre3-dev libpcre3-dbg valgrind python-pip
-  - travis_retry sudo apt-get install -y libestr libestr-dev libfastjson-dev
+  - travis_retry sudo apt-get install -y libestr libestr-devel
+  - travis_retry sudo apt-get install -y libfastjson libfastjson-devel
 # the following is a work-around to solve the
 # "too old autoconf-archive" problem
   - mkdir tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,13 @@ matrix:
 before_install:
 - travis_retry sudo apt-get update -qq
 - travis_retry sudo apt-get install -qq libpcre3-dev libpcre3-dbg valgrind python-pip
+- travis_retry sudo apt-get install -qq libestr-dev libfastjson-dev
+- travis_retry sudo apt-get install -qq clang
 - travis_retry sudo pip install -U sphinx
 - travis_retry sudo add-apt-repository ppa:adiscon/v8-stable -y
 - travis_retry sudo apt-get update -qq
 
 install:
-- travis_retry sudo apt-get install -qq libestr-dev libfastjson-dev
-- travis_retry sudo apt-get install -qq clang
 # the following is a work-around to solve the
 # "too old autoconf-archive" problem
 - mkdir tmp


### PR DESCRIPTION
Build bot log is : 
<pre>
checking for LIBESTR... no
configure: error: Package requirements (libestr >= 0.0.0) were not met:
No package 'libestr' found
Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.
Alternatively, you may set the environment variables LIBESTR_CFLAGS
and LIBESTR_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
</pre>

Try to fix it