### PR TITLE
Fixed a memory leak when a user-defined type has an unparsed result

### DIFF
--- a/src/pdag.c
+++ b/src/pdag.c
@@ -1595,6 +1595,10 @@ LN_DBGPRINTF(dag->ctx, "%zu: enter parser, dag node %p, json %p", offs, dag, jso
 					json_object_put(value);
 				}
 			}
+		} else {
+			if (value != NULL) { /* Free the value if it was created */
+				json_object_put(value);
+			}
 		}
 		/* did we have a longer parser --> then update */
 		if(parsedTo > npb->parsedTo)


### PR DESCRIPTION
Found and closes a memory leak when user-defined types return without a match. 

Closes #223 