### PR TITLE
FIX CEF PARSER

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -2626,7 +2626,8 @@ cefParseExtensionValue(npb_t *const npb,
 			if(npb->str[i] != '=' &&
 			   npb->str[i] != '\\' &&
 			   npb->str[i] != 'r' &&
-			   npb->str[i] != 'n')
+			   npb->str[i] != 'n' && 
+			   npb->str[i] != '/')
 			FAIL(LN_WRONGPARSER);
 			inEscape = 0;
 		} else {
@@ -2703,16 +2704,22 @@ cefParseExtensions(npb_t *const npb,
 			++i;
 		iName = i;
 		CHKR(cefParseName(npb, &i));
-		if(i+1 >= npb->strLen || npb->str[i] != '=')
+
+		if(npb->str[i] != '=')
 			FAIL(LN_WRONGPARSER);
 		lenName = i - iName;
-		++i; /* skip '=' */
+		
+		/* Init if the last value is empty */
+		lenValue = 0;
+		if(i < npb->strLen){
+			++i; /* skip '=' */
 
-		iValue = i;
-		CHKR(cefParseExtensionValue(npb, &i));
-		lenValue = i - iValue;
+			iValue = i;
+			CHKR(cefParseExtensionValue(npb, &i));
+			lenValue = i - iValue;
 
-		++i; /* skip past value */
+			++i; /* skip past value */
+		}
 
 		if(jroot != NULL) {
 			CHKN(name = malloc(sizeof(char) * (lenName + 1)));
@@ -2732,6 +2739,8 @@ cefParseExtensions(npb_t *const npb,
 					case 'r':	value[iDst] = '\r';
 							break;
 					case '\\':	value[iDst] = '\\';
+							break;
+					case '/':	value[iDst] = '/';
 							break;
 					default:	break;
 					}
@@ -2840,7 +2849,9 @@ PARSER_Parse(CEF)
 	CHKR(cefGetHdrField(npb, &i, (value == NULL) ? NULL : &sigID));
 	CHKR(cefGetHdrField(npb, &i, (value == NULL) ? NULL : &name));
 	CHKR(cefGetHdrField(npb, &i, (value == NULL) ? NULL : &severity));
-	++i; /* skip over terminal '|' */
+
+	while(i < npb->strLen && npb->str[i] == ' ') /* skip leading SP */
+		++i;
 
 	/* OK, we now know we have a good header. Now, we need
 	 * to process extensions.

--- a/tests/field_cef.sh
+++ b/tests/field_cef.sh
@@ -39,7 +39,7 @@ execute 'CEF:0|Vendor|Product|Version|Signature ID|some name|Severity| ' # singl
 assert_output_json_eq '{ "f": { "DeviceVendor": "Vendor", "DeviceProduct": "Product", "DeviceVersion": "Version", "SignatureID": "Signature ID", "Name": "some name", "Severity": "Severity", "Extensions": { } } }'
 
 execute 'CEF:0|Vendor|Product|Version|Signature ID|some name|Severity|   ' # multiple trailing spaces - invalid
-assert_output_json_eq '{ "originalmsg": "CEF:0|Vendor|Product|Version|Signature ID|some name|Severity|   ", "unparsed-data": "CEF:0|Vendor|Product|Version|Signature ID|some name|Severity|   " }'
+assert_output_json_eq '{ "f": { "DeviceVendor": "Vendor", "DeviceProduct": "Product", "DeviceVersion": "Version", "SignatureID": "Signature ID", "Name": "some name", "Severity": "Severity", "Extensions": { } } }'
 
 execute 'CEF:0|Vendor'
 assert_output_json_eq '{ "originalmsg": "CEF:0|Vendor", "unparsed-data": "CEF:0|Vendor" }'

--- a/tests/field_cef_jsoncnf.sh
+++ b/tests/field_cef_jsoncnf.sh
@@ -39,7 +39,7 @@ execute 'CEF:0|Vendor|Product|Version|Signature ID|some name|Severity| ' # singl
 assert_output_json_eq '{ "f": { "DeviceVendor": "Vendor", "DeviceProduct": "Product", "DeviceVersion": "Version", "SignatureID": "Signature ID", "Name": "some name", "Severity": "Severity", "Extensions": { } } }'
 
 execute 'CEF:0|Vendor|Product|Version|Signature ID|some name|Severity|   ' # multiple trailing spaces - invalid
-assert_output_json_eq '{ "originalmsg": "CEF:0|Vendor|Product|Version|Signature ID|some name|Severity|   ", "unparsed-data": "CEF:0|Vendor|Product|Version|Signature ID|some name|Severity|   " }'
+assert_output_json_eq '{ "f": { "DeviceVendor": "Vendor", "DeviceProduct": "Product", "DeviceVersion": "Version", "SignatureID": "Signature ID", "Name": "some name", "Severity": "Severity", "Extensions": { } } }'
 
 execute 'CEF:0|Vendor'
 assert_output_json_eq '{ "originalmsg": "CEF:0|Vendor", "unparsed-data": "CEF:0|Vendor" }'


### PR DESCRIPTION
#### Currently, the CEF parser fails for two reasons:
 - When it encounters an escaped slash ( \\/ ) in the middle of a value
 - When the last value is empty

This is particularly problematic for us as we have a lot of data in this format to parse.

### Behavior:
- Log
```log
CEF:0|nxlog.org|nxlog|2.7.1243|Executable Code was Detected|Advanced exploit detected|100|path=Some\/Path spt=46117 dst=172.25.212.204 dpt=
```
- Rulebase
```
version=2
rule=%.:cef%
```
- Expected behavior
```json
{
  "DeviceVendor": "nxlog.org",
  "DeviceProduct": "nxlog",
  "DeviceVersion": "2.7.1243",
  "SignatureID": "Executable Code was Detected",
  "Name": "Advanced exploit detected",
  "Severity": "100",
  "Extensions": {
    "path": "Some/Path",
    "spt": "46117",
    "dst": "172.25.212.204",
    "dpt": ""
  }
}
```
- Current behavior
```json
{
  "originalmsg": "CEF:0|nxlog.org|nxlog|2.7.1243|Executable Code was Detected|Advanced exploit detected|100|path=Some\\/Path spt=46117 dst=172.25.212.204 dpt=",
  "unparsed-data": "CEF:0|nxlog.org|nxlog|2.7.1243|Executable Code was Detected|Advanced exploit detected|100|path=Some\\/Path spt=46117 dst=172.25.212.204 dpt="
}
```

### Tests

With this fix, the CEF parser is now more flexible than before when it comes to the trailing spaces after the headers (it ignores them).
I had to change the tests that were dealing with this behavior.
