### PR TITLE
Fix warnings reported by covscan

### DIFF
--- a/src/liblognorm.c
+++ b/src/liblognorm.c
@@ -165,9 +165,12 @@ ln_loadSamples(ln_ctx ctx, const char *file)
 	ctx->conf_ln_nbr = 0;
 	++ctx->include_level;
 	r = ln_sampLoad(ctx, file);
-	--ctx->include_level;
+	if (r != -1) {
+		--ctx->include_level;
+		ctx->conf_file = NULL;
+	}
+
 	free((void*)tofree);
-	ctx->conf_file = NULL;
 done:
 	return r;
 }

--- a/src/samp.c
+++ b/src/samp.c
@@ -586,7 +586,7 @@ getTypeName(ln_ctx ctx,
 	int r = -1;
 	size_t iDst;
 	size_t i = *offs;
-	
+
 	if(buf[i] != '@') {
 		ln_errprintf(ctx, 0, "user-defined type name must "
 			"start with '@'");
@@ -1139,11 +1139,13 @@ ln_sampLoad(ln_ctx ctx, const char *file)
 	ln_dbgprintf(ctx, "rulebase version is %d\n", version);
 	if(version == -1) {
 		ln_errprintf(ctx, errno, "error determing version of %s", file);
+		fclose(repo);
 		goto done;
 	}
 	if(ctx->version != 0 && version != ctx->version) {
 		ln_errprintf(ctx, errno, "rulebase '%s' must be version %d, but is version %d "
 			" - can not be processed", file, ctx->version, version);
+		fclose(repo);
 		goto done;
 	}
 	ctx->version = version;


### PR DESCRIPTION
I've executed covscan analysis on the liblognorm component, which detected a list of potential defects. The second and fourth seem like false positives to me. Let me know if there is a way to make such a warning disappear.

### Error: USE_AFTER_FREE (CWE-416): [#def1]
```
liblognorm-2.0.6/src/liblognorm.c:167: freed_arg: "ln_sampLoad" frees "ctx".
liblognorm-2.0.6/src/liblognorm.c:168: deref_after_free: Dereferencing freed pointer "ctx".
#  166|   	++ctx->include_level;
#  167|   	r = ln_sampLoad(ctx, file);
#  168|-> 	--ctx->include_level;
#  169|   	free((void*)tofree);
#  170|   	ctx->conf_file = NULL;
```
### Error: RESOURCE_LEAK (CWE-772): [#def2]
```
liblognorm-2.0.6/src/samp.c:812: alloc_fn: Storage is returned from allocation function "ln_newAnnot".
liblognorm-2.0.6/src/samp.c:812: var_assign: Assigning: "annot" = storage returned from "ln_newAnnot(tag)".
liblognorm-2.0.6/src/samp.c:815: noescape: Resource "annot" is not freed or pointed-to in "getAnnotationOp".
liblognorm-2.0.6/src/samp.c:820: leaked_storage: Variable "annot" going out of scope leaks the storage it points to.
#  818|   	r = ln_addAnnotToSet(ctx->pas, annot);
#  819|   
#  820|-> done:	return r;
#  821|   }
#  822|   
```

### Error: RESOURCE_LEAK (CWE-772): [#def3]
```
liblognorm-2.0.6/src/samp.c:1136: alloc_fn: Storage is returned from allocation function "tryOpenRBFile".
liblognorm-2.0.6/src/samp.c:1136: var_assign: Assigning: "repo" = storage returned from "tryOpenRBFile(ctx, file)".
liblognorm-2.0.6/src/samp.c:1138: noescape: Resource "repo" is not freed or pointed-to in "checkVersion".
liblognorm-2.0.6/src/samp.c:1167: leaked_storage: Variable "repo" going out of scope leaks the storage it points to.
# 1165|   		ln_pdagOptimize(ctx);
# 1166|   done:
# 1167|-> 	return r;
# 1168|   }
# 1169|   
```

### Error: RESOURCE_LEAK (CWE-772): [#def4]
```
liblognorm-2.0.6/src/v1_samp.c:747: alloc_fn: Storage is returned from allocation function "ln_newAnnot".
liblognorm-2.0.6/src/v1_samp.c:747: var_assign: Assigning: "annot" = storage returned from "ln_newAnnot(tag)".
liblognorm-2.0.6/src/v1_samp.c:750: noescape: Resource "annot" is not freed or pointed-to in "getAnnotationOp".
liblognorm-2.0.6/src/v1_samp.c:755: leaked_storage: Variable "annot" going out of scope leaks the storage it points to.
#  753|   	r = ln_addAnnotToSet(ctx->pas, annot);
#  754|   
#  755|-> done:	return r;
#  756|   }
#  757|
```