### PR TITLE
LOGNORMALIZER::CHANGED:: when using '-V' flag, return 0 (zero) when program exits

### DIFF
--- a/src/lognormalizer.c
+++ b/src/lognormalizer.c
@@ -360,7 +360,7 @@ int main(int argc, char *argv[])
 		switch (opt) {
 		case 'V':
 			printVersion();
-			exit(1);
+			exit(0);
 			break;
 		case 'd': /* generate DOT file */
 			if(!strcmp(optarg, "")) {


### PR DESCRIPTION
# Description
When printing lognormalizer's version through its '-V' flag, the return code is not zero, that return code is counter intuitive and prevents using the command in scripts and/or CI/CD frameworks

# Changed
- return zero when '-V' flag is detected after printing the version number, instead of 1