### PR TITLE
Remove problematic language from the code

### DIFF
--- a/README
+++ b/README
@@ -27,7 +27,7 @@ https://www.researchgate.net/publication/310545144_Efficient_Normalization_of_IT
 
 The current library is the result of that effort. Application developers
 are encouraged to switch to this version, as it provides the benefit of
-a simpler API. This version is now being tracked by the git master branch.
+a simpler API. This version is now being tracked by the git default branch.
 
 However, if you need to stick to the old API, there is a git branch
 liblognorm0, which contains the previous version of the library. This

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -37,9 +37,6 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
-
 # General information about the project.
 project = u'Liblognorm'
 # pylint: disable=W0141

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,4 +1,4 @@
-.. Liblognorm documentation master file, created by
+.. Liblognorm documentation main file, created by
    sphinx-quickstart on Mon Dec 16 13:12:44 2013.
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.


### PR DESCRIPTION
I would like to replace problematic terms [1] with alternatives that are appropriate to the particular project and context. The change does not affect the functionality. I purposely removed master_doc from ```doc/conf.py``` , because if it's not specified then the default 'index' is used [2].

[1] https://inclusivenaming.org/word-lists/tier-1/
[2] https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-master_doc