### PR TITLE
Repeat - Fix multiple patterns with one name

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -3029,12 +3029,12 @@ chkNoDupeDotInParserDefs(ln_ctx ctx, struct json_object *parsers)
 	if(json_object_get_type(parsers) == json_type_array) {
 		const int maxparsers = json_object_array_length(parsers);
 		for(int i = 0 ; i < maxparsers ; ++i) {
-			++nParsers;
 			struct json_object *const parser
 				= json_object_array_get_idx(parsers, i);
 			struct json_object *fname;
 			json_object_object_get_ex(parser, "name", &fname);
 			if(fname != NULL) {
+				++nParsers;
 				if(!strcmp(json_object_get_string(fname), "."))
 					++nDots;
 			}

--- a/tests/repeat_name_dot.sh
+++ b/tests/repeat_name_dot.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# added 2023-02-14 by Kevin Guillemot
+# This file is part of the liblognorm project, released under ASL 2.0
+
+. $srcdir/exec.sh
+
+test_def $0 "Repeat with one parser named dot"
+add_rule 'version=2'
+add_rule 'rule=:a %{"name":"numbers", "type":"repeat",
+			"parser":[
+			  {"type":"number"},
+			  {"type":"literal", "text":":"},
+			  {"name":".", "type":"number"}
+			  ],
+			"while":[
+			  {"type":"literal", "text":", "}
+			]
+       		   }% b %w:word%
+'
+execute 'a 1:2, 3:4, 5:6, 7:8 b test'
+assert_output_json_eq '{ "w": "test", "numbers": [ "2", "4", "6", "8" ] }'
+
+cleanup_tmp_files


### PR DESCRIPTION
### Actual behavior
Actually, when using the following rulebase : 
```
version=2
rule=:%
        {"name":"numbers", "type":"repeat",
            "parser":[
                       {"type":"number"},
                       {"type":"literal", "text":":"},
                       {"type":"number", "name": "."}
                     ],
            "while":[
                       {"type":"literal", "text":", "}
                    ]
         }%
```
And the following line to parse : 
```
1:2, 3:4, 5:6, 7:8
```
I get the following error : 
```sh
$ echo '1:2, 3:4, 5:6, 7:8' | lognormalizer -r ./test.rb
liblognorm error: rulebase file ./test.rb[12]: 'repeat' parser supports dot name only if single parser is used in 'parser' part, invalid construct: [ { "type": "number" }, { "type": "literal", "text": ":" }, { "type": "number", "name": "." } ]
liblognorm error: rulebase file ./test.rb[12]: repeat parser needs 'parser','while' parameters
Erreur de segmentation
```

The error **'repeat' parser supports dot name only if single parser is used** should be raised only if **2** parsers have a **name** configured.

### Fixed behavior

After fixing, when using the rule and line listed above, the error does not raise and the parsing behavior is as expected.
```sh
$ echo '1:2, 3:4, 5:6, 7:8' | lognormalizer -r ./test.rb
{ "numbers": [ "2", "4", "6", "8" ] }
```

### Non-regression tests

After fix, the error correctly raises when multiple parsers use a name : 
```
version=2
rule=:%
        {"name":"numbers", "type":"repeat",
            "parser":[
                       {"type":"number", "name": "n1"},
                       {"type":"literal", "text":":"},
                       {"type":"number", "name": "."}
                     ],
            "while":[
                       {"type":"literal", "text":", "}
                    ]
         }%
```
```sh
$ echo '1:2, 3:4, 5:6, 7:8' | lognormalizer -r ./test.rb
liblognorm error: rulebase file ./test.rb[12]: 'repeat' parser supports dot name only if single parser is used in 'parser' part, invalid construct: [ { "type": "number", "name": "n1" }, { "type": "literal", "text": ":" }, { "type": "number", "name": "." } ]
liblognorm error: rulebase file ./test.rb[12]: repeat parser needs 'parser','while' parameters
Erreur de segmentation
```