### PR TITLE
Add support for nested objects with exclamation mark

### DIFF
--- a/src/pdag.c
+++ b/src/pdag.c
@@ -1409,8 +1409,11 @@ fixJSON(struct ln_pdag *dag,
 			json_object_put(*value);
 			json_object_object_add_ex(json, prs->name, valDotDot,
 				JSON_C_OBJECT_ADD_KEY_IS_NEW|JSON_C_OBJECT_KEY_IS_CONSTANT);
-		} else {
+		} else if(dag->ctx->version == 3) {
 			add_json_nested_key_value_pair(json, (char *)prs->name, *value);
+		} else {
+			json_object_object_add_ex(json, prs->name, *value,
+                                      JSON_C_OBJECT_ADD_KEY_IS_NEW|JSON_C_OBJECT_KEY_IS_CONSTANT);
 		}
 	}
 	r = 0;

--- a/src/samp.c
+++ b/src/samp.c
@@ -1062,6 +1062,8 @@ checkVersion(FILE *const fp)
 		return -1;
 	if(!strcmp(buf, "version=2\n")) {
 		return 2;
+	} else if(!strcmp(buf, "version=3\n")) {
+		return 3;
 	} else {
 		return 1;
 	}
@@ -1154,7 +1156,7 @@ ln_sampLoad(ln_ctx ctx, const char *file)
 	}
 
 	/* now we are in our native code */
-	++ctx->conf_ln_nbr; /* "version=2" is line 1! */
+	++ctx->conf_ln_nbr; /* "version=2" or "version=3" is line 1! */
 	while(!isEof) {
 		CHKR(ln_sampRead(ctx, repo, NULL, &isEof));
 	}
@@ -1178,7 +1180,7 @@ ln_sampLoadFromString(ln_ctx ctx, const char *string)
 		goto done;
 
 	ln_dbgprintf(ctx, "loading v2 rulebase from string '%s'", string);
-	ctx->version = 2;
+	ctx->version = 3;
 	while(!isEof) {
 		CHKR(ln_sampRead(ctx, NULL, &string, &isEof));
 	}

--- a/tests/field_v3_nested.sh
+++ b/tests/field_v3_nested.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# added 2023-09-25 by KGuillemot
+# This file is part of the liblognorm project, released under ASL 2.0
+. $srcdir/exec.sh
+no_solaris10
+
+test_def $0 "v3 name-value-list parser"
+
+add_rule 'version=3'
+add_rule 'rule=:<%syslog!priority:number%>%received!time:date-rfc3164% %host!name:word% %log!data:name-value-list%'
+
+execute '<15>Feb 10 08:30:07 hostname a=b c=d y=z'
+assert_output_json_eq '{ "log": { "data": { "a": "b", "c": "d", "y": "z" } }, "host": { "name": "hostname" }, "received": { "time": "Feb 10 08:30:07" }, "syslog": { "priority": "15" } }'
+
+cleanup_tmp_files
+


### PR DESCRIPTION
### Actual behavior

Currently, when using the following rulebase : 
```
version=2
rule=:%a!b:rest%
```
And the following line to parse : 
```
line to parse
```

The result is : 
```json
{ "a!b": "line to parse" }
```

### New behavior

With the proposed improvement, when using the same rulebase and the same line to parse as above, the result is now : 
```json
{ "a": { "b": "line to parse" } }
```

**Note that this is a breaking change in case of using exclamation mark in captured names.**

### Notes

I tried to add the new behavior as an option, for example by adding "nested=" at the beginning of rulebase files, but I encountered some issues by using file inclusion or with the Rsyslog mmnormalize module by using the directive "rule=".

Please let me know if you have a better option to add this new behavior as a option, or to prevent breaking change, but this new behavior makes sens regarding the access of nested variables in Rsyslog by using exclamation marks. 

