### PR TITLE
Add asprintf to autoconf function check macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,7 @@ AC_TYPE_SIZE_T
 AC_FUNC_SELECT_ARGTYPES
 AC_TYPE_SIGNAL
 AC_FUNC_STRERROR_R
-AC_CHECK_FUNCS([strdup strndup strtok_r])
+AC_CHECK_FUNCS([asprintf strdup strndup strtok_r])
 
 LIBLOGNORM_CFLAGS="-I\$(top_srcdir)/src"
 LIBLOGNORM_LIBS="\$(top_builddir)/src/liblognorm.la"


### PR DESCRIPTION
Compatibility code was compiled even on systems which didn't require. This became evident when Clang-17 failed to compile it https://bugs.gentoo.org/900583.

I'm not addressing the Clang-17 issue here so it's still an issue for Solaris.