### PR TITLE
parser: fix quoted Checkpoint LEA terminators

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -3472,13 +3472,20 @@ PARSER_Parse(CheckpointLEA)
 		lenName = i - iName;
 		++i; /* skip ':' */
 
-		while(i < npb->strLen && npb->str[i] == ' ') /* skip leading SP */
+		while(i < npb->strLen && npb->str[i] == ' ') { /* skip leading SP */
 			++i;
+		}
 		/* Improvement by KGuillemot & M4jr0 to support quoted values */
 		if( npb->str[i] == '"' ) {
+			int continuous_backslash = 0;
 			iValue = i+1;
 			i++;
-			while( i < npb->strLen && ( npb->str[i] != '"' || npb->str[i-1] == '\\' ) ) {
+			while( i < npb->strLen && ( npb->str[i] != '"' || (continuous_backslash & 1) == 1 ) ) {
+				if(npb->str[i] == '\\') {
+					++continuous_backslash;
+				} else {
+					continuous_backslash = 0;
+				}
 				++i;
 			}
 			// Do not take the " in value
@@ -3491,6 +3498,13 @@ PARSER_Parse(CheckpointLEA)
 				++i;
 			}
 			lenValue = i - iValue;
+			while(lenValue > 0 && npb->str[iValue + lenValue - 1] == ' ') {
+				--lenValue;
+			}
+		}
+
+		while(i < npb->strLen && npb->str[i] == ' ') {
+			++i;
 		}
 
 		if(i+1 > npb->strLen || (npb->str[i] != ';' && npb->str[i] != data->terminator))
@@ -3525,7 +3539,7 @@ done:
 	free(val);
 	if(r != 0 && value != NULL && *value != NULL) {
 		json_object_put(*value);
-		value = NULL;
+		*value = NULL;
 	}
 	return r;
 }

--- a/src/v1_parser.c
+++ b/src/v1_parser.c
@@ -3169,13 +3169,31 @@ PARSER(CheckpointLEA)
 
 		while(i < strLen && str[i] == ' ') /* skip leading SP */
 			++i;
-		iValue = i;
-		while(i < strLen && str[i] != ';') {
+		if(str[i] == '"') {
+			int continuous_backslash = 0;
+			iValue = i + 1;
 			++i;
+			while(i < strLen && (str[i] != '"' || (continuous_backslash & 1) == 1)) {
+				if(str[i] == '\\') {
+					++continuous_backslash;
+				} else {
+					continuous_backslash = 0;
+				}
+				++i;
+			}
+			if(i >= strLen || str[i] != '"')
+				FAIL(LN_WRONGPARSER);
+			lenValue = i - iValue;
+			++i; /* skip closing quote */
+		} else {
+			iValue = i;
+			while(i < strLen && str[i] != ';') {
+				++i;
+			}
+			lenValue = i - iValue;
 		}
 		if(i+1 > strLen || str[i] != ';')
 			FAIL(LN_WRONGPARSER);
-		lenValue = i - iValue;
 		++i; /* skip ';' */
 
 		if(value != NULL) {
@@ -3204,7 +3222,7 @@ done:
 	free(val);
 	if(r != 0 && value != NULL && *value != NULL) {
 		json_object_put(*value);
-		value = NULL;
+		*value = NULL;
 	}
 	return r;
 }

--- a/tests/field_checkpoint-lea-terminator.sh
+++ b/tests/field_checkpoint-lea-terminator.sh
@@ -10,9 +10,17 @@ add_rule 'rule=:[ %{"name":"f", "type":"checkpoint-lea", "terminator": "]"}%]'
 execute '[ tcp_flags: RST-ACK; src: 192.168.0.1; ]'
 assert_output_json_eq '{ "f": { "tcp_flags": "RST-ACK", "src": "192.168.0.1" } }'
 
+execute '[ tcp_flags: RST-ACK; src: 192.168.0.1 ]'
+assert_output_json_eq '{ "f": { "tcp_flags": "RST-ACK", "src": "192.168.0.1" } }'
+
 # Newest Checkpoint format
 execute '[ tcp_flags:"RST-ACK"; src:"192.168.0.1"; ]'
 assert_output_json_eq '{ "f": { "tcp_flags": "RST-ACK", "src": "192.168.0.1" } }'
 
-cleanup_tmp_files
+execute '[ tcp_flags:"RST-ACK"; src:"192.168.0.1" ]'
+assert_output_json_eq '{ "f": { "tcp_flags": "RST-ACK", "src": "192.168.0.1" } }'
 
+execute '[ key:"value with \"escaped quote\""; path:"C:\\Windows\\System32" ]'
+assert_output_json_eq '{ "f": { "key": "value with \\\"escaped quote\\\"", "path": "C:\\\\Windows\\\\System32" } }'
+
+cleanup_tmp_files

--- a/tests/field_checkpoint-lea_v1.sh
+++ b/tests/field_checkpoint-lea_v1.sh
@@ -13,5 +13,7 @@ assert_output_json_eq '{ "f": { "tcp_flags": "RST-ACK", "src": "192.168.0.1" } }
 execute 'tcp_flags:"RST-ACK"; src:"192.168.0.1";'
 assert_output_json_eq '{ "f": { "tcp_flags": "RST-ACK", "src": "192.168.0.1" } }'
 
-cleanup_tmp_files
+execute 'key:"value with \"escaped quote\""; path:"C:\\Windows\\System32";'
+assert_output_json_eq '{ "f": { "key": "value with \\\"escaped quote\\\"", "path": "C:\\\\Windows\\\\System32" } }'
 
+cleanup_tmp_files


### PR DESCRIPTION
## Summary
This follows up on the Checkpoint LEA terminator work merged via PR #325.
That change relaxed the final semicolon requirement for unquoted values,
but quoted final values before the configured terminator still failed.

## What changed
- allow optional spaces before the configured terminator after quoted LEA values
- trim trailing spaces from unquoted final values before the terminator
- clear the partially built JSON object pointer on parser failure
- extend the terminator regression test for quoted and unquoted no-semicolon cases

## Validation
- `make -C src ln_test`
- `cd tests && srcdir=. top_builddir=.. bash ./field_checkpoint-lea-terminator.sh`
- direct repro for `[ tcp_flags:"RST-ACK"; src:"192.168.0.1" ]`
