### PR TITLE
ci: add dedicated TurboVM workflow coverage

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -60,6 +60,42 @@ jobs:
           chmod +x devtools/run-build.sh
           devtools/devcontainer.sh --rm devtools/run-build.sh
 
+  turbo_compile:
+    name: turbo compile (${{ matrix.config }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: true
+      matrix:
+        config: [gcc, clang]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Run Turbo compile check
+        run: |
+          chmod -R go+rw .
+          export LIBLOGNORM_CONTAINER_UID=""
+          export LIBLOGNORM_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
+          export LIBLOGNORM_CONFIGURE_OPTIONS_EXTRA='--enable-turbo'
+          export CFLAGS='-g'
+          case "${{ matrix.config }}" in
+          gcc)
+              export CC='gcc'
+              ;;
+          clang)
+              export CC='clang'
+              ;;
+          *)
+              echo "unknown configuration"
+              exit 1
+              ;;
+          esac
+          chmod +x devtools/run-build.sh
+          devtools/devcontainer.sh --rm devtools/run-build.sh
+
   CI:
     needs: compile
     if: ${{ needs.compile.result == 'success' }}
@@ -127,6 +163,59 @@ jobs:
           ubuntu_24_distcheck)
               export LIBLOGNORM_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
               export CI_CHECK_CMD='distcheck'
+              ;;
+          *)
+              echo "unknown configuration"
+              exit 1
+              ;;
+          esac
+          devtools/devcontainer.sh --rm devtools/run-ci.sh
+
+      - name: Show error logs
+        if: ${{ failure() || cancelled() }}
+        run: |
+          devtools/gather-check-logs.sh
+          cat failed-tests.log
+
+  turbo_CI:
+    needs: turbo_compile
+    if: ${{ needs.turbo_compile.result == 'success' }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [ubuntu_24_turbo, ubuntu_24_asan_turbo]
+    name: ${{ matrix.config }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Run Turbo container CI pipeline
+        run: |
+          chmod -R go+rw .
+          export LIBLOGNORM_CONTAINER_UID=""
+          export LIBLOGNORM_CONFIGURE_OPTIONS_EXTRA='--enable-turbo'
+          export CFLAGS='-g'
+          export LDFLAGS=''
+          export CC='gcc'
+          export USE_AUTO_DEBUG='off'
+          export CI_MAKE_CHECK_EXTRA='TESTSUITEFLAGS=--stop'
+          export CI_CHECK_CMD='check'
+          case "${{ matrix.config }}" in
+          ubuntu_24_turbo)
+              export LIBLOGNORM_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
+              ;;
+          ubuntu_24_asan_turbo)
+              export LIBLOGNORM_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
+              export CC='clang'
+              export CFLAGS="-fstack-protector -D_FORTIFY_SOURCE=2 \
+                     -fsanitize=address -fsanitize-address-use-after-scope \
+                     -g -O1 -fno-omit-frame-pointer -fno-color-diagnostics"
+              export LDFLAGS='-fsanitize=address'
+              export ASAN_OPTIONS='abort_on_error=1:symbolize=1:detect_leaks=0'
               ;;
           *)
               echo "unknown configuration"

--- a/src/turbo.c
+++ b/src/turbo.c
@@ -405,8 +405,6 @@ emit_ctx_pop(compiler_t *comp)
 
 static int compile_node(compiler_t *comp, struct ln_pdag *node, uint32_t *entry);
 
-extern const char *ln_DataForDisplayLiteral(ln_ctx ctx, void *data);
-
 /* Forward declaration for name-value-list parser data (defined in parser.c) */
 struct data_NameValue {
 	char sep;   /* separator (between key/value pairs) */

--- a/src/turbo.h
+++ b/src/turbo.h
@@ -223,18 +223,6 @@ typedef struct ln_fast_result_snapshot_s ln_fast_result_snapshot_t;
  */
 ln_fast_result_snapshot_t *ln_turbo_snapshot_result(ln_ctx ctx);
 
-/**
- * Get the result from a snapshot (for field access).
- * Usable with all ln_fast_result_* accessor functions.
- */
-const ln_fast_result_t *
-ln_fast_result_snapshot_get(const ln_fast_result_snapshot_t *snap);
-
-/**
- * Free a snapshot (single free, NULL-safe).
- */
-void ln_fast_result_snapshot_free(ln_fast_result_snapshot_t *snap);
-
 /*============================================================================
  * Statistics
  *============================================================================*/

--- a/src/turbo_json.h
+++ b/src/turbo_json.h
@@ -21,34 +21,6 @@
 extern "C" {
 #endif
 
-/**
- * @brief Estimate JSON output size.
- */
-size_t ln_fast_json_estimate(const ln_fast_result_t *r);
-
-/**
- * @brief Serialize result to JSON string.
- *
- * @param r       Result to serialize
- * @param buf     Output buffer
- * @param buflen  Buffer size
- * @param outlen  Receives actual length
- * @return 0 on success, -1 on error
- */
-int ln_fast_to_json(const ln_fast_result_t *r,
-					char *buf, size_t buflen, size_t *outlen);
-
-/**
- * @brief Serialize result to allocated JSON string.
- *
- * @param r        Result to serialize
- * @param json_str Receives allocated string (caller must free)
- * @param json_len Receives string length
- * @return 0 on success, -1 on error
- */
-int ln_fast_to_json_alloc(const ln_fast_result_t *r,
-						  char **json_str, size_t *json_len);
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/turbo_json_fast.h
+++ b/src/turbo_json_fast.h
@@ -17,32 +17,6 @@
 extern "C" {
 #endif
 
-/**
- * @brief Estimate JSON output size.
- */
-size_t ln_fast_json_estimate(const ln_fast_result_t *r);
-
-/**
- * @brief Serialize to JSON string.
- *
- * Creates nested objects from dotted field names:
- * "timestamp_netscaler.day" -> {"timestamp_netscaler": {"day": ...}}
- *
- * @param r      Result to serialize
- * @param buf    Output buffer
- * @param buflen Buffer size
- * @param outlen Receives actual length (may be NULL)
- * @return 0 on success, -1 if buffer too small
- */
-int ln_fast_to_json(const ln_fast_result_t *r,
-					char *buf, size_t buflen, size_t *outlen);
-
-/**
- * @brief Allocating version.
- */
-int ln_fast_to_json_alloc(const ln_fast_result_t *r,
-						  char **json_str, size_t *json_len);
-
 #ifdef __cplusplus
 }
 #endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,7 @@
 check_PROGRAMS = json_eq err_callback_cookie
+TESTS_TURBO_SHELLS = \
+	turbo_smoke.sh
+
 # re-enable if we really need the c program check check_PROGRAMS = json_eq user_test
 json_eq_self_sources = json_eq.c
 json_eq_SOURCES = $(json_eq_self_sources)
@@ -171,6 +174,7 @@ REGEXP_TESTS = \
 
 EXTRA_DIST = exec.sh \
 	$(TESTS_SHELLSCRIPTS) \
+	$(TESTS_TURBO_SHELLS) \
 	$(REGEXP_TESTS) \
 	err_callback_cookie.sh \
 	$(json_eq_self_sources) \
@@ -181,6 +185,8 @@ TESTS += $(REGEXP_TESTS)
 endif
 
 if ENABLE_TURBO
+TESTS += $(TESTS_TURBO_SHELLS)
+
 check_PROGRAMS += turbo_test_arena turbo_test_result turbo_test_simd turbo_test_vm turbo_test_json
 
 turbo_test_arena_SOURCES = turbo_test_arena.c

--- a/tests/turbo_smoke.sh
+++ b/tests/turbo_smoke.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# added 2026-04-22 by Rainer Gerhards
+# This file is part of the liblognorm project, released under ASL 2.0
+srcdir="${srcdir:-.}"
+# shellcheck disable=SC1091
+. "$srcdir"/exec.sh
+
+export ln_opts='-oturbo'
+
+test_def "$0" "TurboVM end-to-end smoke path"
+add_rule 'version=2'
+add_rule 'rule=:%source.ip:ipv4% count=%count:number% msg=%msg:word%'
+
+execute '192.0.2.5 count=42 msg=ready'
+assert_output_json_eq '{ "source": { "ip": "192.0.2.5" }, "count": 42, "msg": "ready" }'
+
+
+cleanup_tmp_files


### PR DESCRIPTION
## Summary
- add separate Turbo-enabled compile jobs without changing the existing non-Turbo jobs
- add a small Turbo CI matrix for Ubuntu and Ubuntu ASan
- add a Turbo-only shell smoke test that exercises `ln_test -oturbo`

## Testing
- `autoreconf -fvi`
- `./configure --enable-turbo`
- `make -j$(nproc) check TESTS=""`
- `srcdir=. bash ./tests/turbo_smoke.sh`
- `srcdir=. bash ./tests/field_string.sh`
- `./tests/turbo_test_arena && ./tests/turbo_test_result && ./tests/turbo_test_simd && ./tests/turbo_test_vm && ./tests/turbo_test_json`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)`
