### PR TITLE
repeat: allow one named dot among unnamed parsers

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -3641,12 +3641,12 @@ chkNoDupeDotInParserDefs(ln_ctx ctx, struct json_object *parsers)
 	if(json_object_get_type(parsers) == json_type_array) {
 		const int maxparsers = json_object_array_length(parsers);
 		for(int i = 0 ; i < maxparsers ; ++i) {
-			++nParsers;
 			struct json_object *const parser
 				= json_object_array_get_idx(parsers, i);
 			struct json_object *fname;
 			json_object_object_get_ex(parser, "name", &fname);
 			if(fname != NULL) {
+				++nParsers;
 				if(!strcmp(json_object_get_string(fname), "."))
 					++nDots;
 			}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -64,6 +64,7 @@ TESTS_SHELLSCRIPTS = \
 	repeat_mismatch_in_while.sh \
 	repeat_while_alternative.sh \
 	repeat_alternative_nested.sh \
+	repeat_name_dot.sh \
 	parser_prios.sh \
 	parser_whitespace.sh \
 	parser_whitespace_jsoncnf.sh \

--- a/tests/repeat_name_dot.sh
+++ b/tests/repeat_name_dot.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# added 2023-02-14 by Kevin Guillemot
+# This file is part of the liblognorm project, released under ASL 2.0
+
+. $srcdir/exec.sh
+
+test_def $0 "Repeat with one parser named dot"
+add_rule 'version=2'
+add_rule 'rule=:a %{"name":"numbers", "type":"repeat",
+			"parser":[
+			  {"type":"number"},
+			  {"type":"literal", "text":":"},
+			  {"name":".", "type":"number"}
+			  ],
+			"while":[
+			  {"type":"literal", "text":", "}
+			]
+       		   }% b %w:word%
+'
+execute 'a 1:2, 3:4, 5:6, 7:8 b test'
+assert_output_json_eq '{ "w": "test", "numbers": [ "2", "4", "6", "8" ] }'
+
+cleanup_tmp_files

--- a/tests/repeat_name_dot.sh
+++ b/tests/repeat_name_dot.sh
@@ -2,9 +2,11 @@
 # added 2023-02-14 by Kevin Guillemot
 # This file is part of the liblognorm project, released under ASL 2.0
 
-. $srcdir/exec.sh
+srcdir="${srcdir:-.}"
+# shellcheck disable=SC1091
+. "$srcdir"/exec.sh
 
-test_def $0 "Repeat with one parser named dot"
+test_def "$0" "Repeat with one parser named dot"
 add_rule 'version=2'
 add_rule 'rule=:a %{"name":"numbers", "type":"repeat",
 			"parser":[


### PR DESCRIPTION
Follow-up to #369.

I opened this refreshed PR from `rgerhards:pr369-repeat-named-dot` because the original head repository for #369 does not allow maintainer pushes, so the branch could not be rebased and completed in place.

This branch contains both commits needed for merge readiness:
- the original parser fix by Kevin Guillemot <kevin.guillemot@advens.fr>
- a narrow follow-up by Rainer Gerhards <rgerhards@adiscon.com> that registers the new regression test and updates it to current shell-harness style

Compared to #369, this version is rebased onto current `main`, keeps the parser change itself intact, and makes sure the new repeat coverage is actually executed in CI and included in dist artifacts.

Closing #369 in favor of this PR keeps review on the only branch that can actually be updated.