### PR TITLE
gitignore: ignore local Codex agent notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ doc/_build/
 *.la
 *.lo
 *.o
+
+# Local machine-specific Codex notes
+AGENTS.local.md


### PR DESCRIPTION
## Summary
- Ignore `AGENTS.local.md` for machine-specific Codex notes.

## Testing
- Not run; ignore-only change.