### PR TITLE
ci: harden GitHub Actions security

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Security-sensitive repository metadata
+/.gitmodules @rgerhards @alorbach
+/.gitattributes @rgerhards @alorbach
+
+# CI workflows
+/.github/workflows/* @rgerhards @alorbach

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Security-sensitive repository metadata
+/.github/CODEOWNERS @rgerhards @alorbach
 /.gitmodules @rgerhards @alorbach
 /.gitattributes @rgerhards @alorbach
 
 # CI workflows
-/.github/workflows/* @rgerhards @alorbach
+/.github/workflows/ @rgerhards @alorbach

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,12 +7,21 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
+    name: actionlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - name: Lint GitHub Actions workflows
-        uses: reviewdog/action-actionlint@v1
+        uses: reviewdog/action-actionlint@e0207a28405ecad11953ba625a95d92f7889572a # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          filter_mode: file
+          fail_level: any

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,14 +24,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
-      actions: read
+      actions: read # CodeQL reads Actions metadata for workflow analysis.
       contents: read
-      security-events: write
+      security-events: write # CodeQL uploads results to code scanning.
 
     strategy:
       fail-fast: false
@@ -40,7 +42,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Install packages
         if: ${{ matrix.language == 'cpp' }}
@@ -55,7 +59,7 @@ jobs:
             pkg-config
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@53e96ec3b35fce51c141c0d6f0e31028a448722d # v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
@@ -68,6 +72,6 @@ jobs:
           make
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@53e96ec3b35fce51c141c0d6f0e31028a448722d # v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -24,6 +24,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   compile:
     name: compile (${{ matrix.config }})
@@ -37,15 +39,19 @@ jobs:
         config: [gcc, clang]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Run compile check
+        env:
+          MATRIX_CONFIG: ${{ matrix.config }}
         run: |
           chmod -R go+rw .
           export LIBLOGNORM_CONTAINER_UID=""
           export LIBLOGNORM_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
           export CFLAGS='-g'
-          case "${{ matrix.config }}" in
+          case "$MATRIX_CONFIG" in
           gcc)
               export CC='gcc'
               ;;
@@ -72,16 +78,20 @@ jobs:
         config: [gcc, clang]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Run Turbo compile check
+        env:
+          MATRIX_CONFIG: ${{ matrix.config }}
         run: |
           chmod -R go+rw .
           export LIBLOGNORM_CONTAINER_UID=""
           export LIBLOGNORM_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
           export LIBLOGNORM_CONFIGURE_OPTIONS_EXTRA='--enable-turbo'
           export CFLAGS='-g'
-          case "${{ matrix.config }}" in
+          case "$MATRIX_CONFIG" in
           gcc)
               export CC='gcc'
               ;;
@@ -114,9 +124,13 @@ jobs:
     name: ${{ matrix.config }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Run container CI pipeline
+        env:
+          MATRIX_CONFIG: ${{ matrix.config }}
         run: |
           chmod -R go+rw .
           export LIBLOGNORM_CONTAINER_UID=""
@@ -126,7 +140,7 @@ jobs:
           export USE_AUTO_DEBUG='off'
           export CI_MAKE_CHECK_EXTRA='TESTSUITEFLAGS=--stop'
           export CI_CHECK_CMD='check'
-          case "${{ matrix.config }}" in
+          case "$MATRIX_CONFIG" in
           centos_8)
               export LIBLOGNORM_DEV_CONTAINER='rsyslog/rsyslog_dev_base_centos:8'
               ;;
@@ -191,9 +205,13 @@ jobs:
     name: ${{ matrix.config }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Run Turbo container CI pipeline
+        env:
+          MATRIX_CONFIG: ${{ matrix.config }}
         run: |
           chmod -R go+rw .
           export LIBLOGNORM_CONTAINER_UID=""
@@ -204,7 +222,7 @@ jobs:
           export USE_AUTO_DEBUG='off'
           export CI_MAKE_CHECK_EXTRA='TESTSUITEFLAGS=--stop'
           export CI_CHECK_CMD='check'
-          case "${{ matrix.config }}" in
+          case "$MATRIX_CONFIG" in
           ubuntu_24_turbo)
               export LIBLOGNORM_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
               ;;
@@ -254,19 +272,21 @@ jobs:
     name: ${{ matrix.arch }} CI (${{ matrix.use_qemu && 'QEMU' || 'native, asan' }})
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU for ${{ matrix.arch }} emulation
         if: ${{ matrix.use_qemu }}
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         with:
           platforms: ${{ matrix.qemu_platform }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build ${{ matrix.arch }} dev image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: devtools/ci/Dockerfile.arm
@@ -277,16 +297,20 @@ jobs:
           cache-to: type=gha,mode=max,scope=arm-dev-${{ matrix.arch }}
 
       - name: Run ${{ matrix.arch }} CI pipeline
+        env:
+          MATRIX_ARCH: ${{ matrix.arch }}
+          MATRIX_PLATFORM: ${{ matrix.platform }}
+          WORKSPACE_PATH: ${{ github.workspace }}
         run: |
           chmod -R go+rw .
-          docker run --rm --platform ${{ matrix.platform }} \
-            -e ARCH=${{ matrix.arch }} \
+          docker run --rm --platform "$MATRIX_PLATFORM" \
+            -e ARCH="$MATRIX_ARCH" \
             --cap-add SYS_ADMIN \
             --cap-add SYS_PTRACE \
             --security-opt seccomp=unconfined \
-            -v "${{ github.workspace }}:/rsyslog" \
+            -v "$WORKSPACE_PATH:/rsyslog" \
             -w /rsyslog \
-            liblognorm-arm-dev:${{ matrix.arch }} bash -c '
+            "liblognorm-arm-dev:$MATRIX_ARCH" bash -c '
               set -e
               export CC=gcc
               export CFLAGS="-g -O1 -fno-omit-frame-pointer"
@@ -318,8 +342,9 @@ jobs:
     name: clang static analyzer
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Run clang static analyzer
@@ -342,7 +367,7 @@ jobs:
       - name: Upload clang static analyzer report
         if: ${{ always() }}
         id: upload-report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: clang-static-analyzer-report
           path: scan-build-report
@@ -351,8 +376,10 @@ jobs:
 
       - name: Show clang static analyzer report link
         if: ${{ always() }}
+        env:
+          ARTIFACT_URL: ${{ steps.upload-report.outputs.artifact-url }}
         run: |
-          artifact="${{ steps.upload-report.outputs.artifact-url }}"
+          artifact="$ARTIFACT_URL"
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
           Clang static analyzer HTML report (download):
           $artifact
@@ -362,8 +389,10 @@ jobs:
 
       - name: Fail if analysis failed
         if: ${{ steps.run-clang.outputs.exitcode != '0' }}
+        env:
+          ARTIFACT_URL: ${{ steps.upload-report.outputs.artifact-url }}
         run: |
-          artifact="${{ steps.upload-report.outputs.artifact-url }}"
+          artifact="$ARTIFACT_URL"
           echo "clang static analyzer detected issues:" >&2
           tail -n 200 clang-analyzer.log >&2 || true
           echo >&2
@@ -385,7 +414,9 @@ jobs:
     name: rsyslog integration
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Run rsyslog integration tests
         env:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -13,16 +13,18 @@ permissions:
 
 jobs:
   lint:
+    name: shellcheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          persist-credentials: false
           fetch-depth: 2
 
       - name: Identify changed shell files
         id: changed
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           separator: "\n"
           files: |
@@ -35,8 +37,10 @@ jobs:
 
       - name: Run shellcheck
         if: steps.changed.outputs.any_changed == 'true'
+        env:
+          CHANGED_SHELL_FILES: ${{ steps.changed.outputs.all_changed_files }}
         run: |
-          printf '%s\n' '${{ steps.changed.outputs.all_changed_files }}' | sed 's/\\$//' > changed-shell-files.txt
+          printf '%s\n' "$CHANGED_SHELL_FILES" | sed 's/\\$//' > changed-shell-files.txt
           mapfile -t files < changed-shell-files.txt
           shellcheck "${files[@]}"
 

--- a/.github/workflows/yaml_lint.yml
+++ b/.github/workflows/yaml_lint.yml
@@ -29,16 +29,18 @@ permissions:
 
 jobs:
   lint:
+    name: yamllint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          persist-credentials: false
           fetch-depth: 2
 
       - name: Identify changed YAML files
         id: changed
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           separator: "\n"
           files: |
@@ -51,8 +53,10 @@ jobs:
 
       - name: Run yamllint
         if: steps.changed.outputs.any_changed == 'true'
+        env:
+          CHANGED_YAML_FILES: ${{ steps.changed.outputs.all_changed_files }}
         run: |
-          printf '%s\n' '${{ steps.changed.outputs.all_changed_files }}' | sed 's/\\$//' > changed-yaml-files.txt
+          printf '%s\n' "$CHANGED_YAML_FILES" | sed 's/\\$//' > changed-yaml-files.txt
           mapfile -t files < changed-yaml-files.txt
           yamllint \
             -d '{extends: relaxed, rules: {line-length: {max: 120}}}' \

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -20,6 +20,7 @@ jobs:
   zizmor:
     name: zizmor
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -33,4 +34,7 @@ jobs:
         with:
           advanced-security: false
           annotations: true
+          inputs: .github
+          online-audits: false
           persona: auditor
+          version: v1.24.1

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+---
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  pull_request:
+  push:
+    branches: [ "main" ]
+    paths:
+      - ".github/**"
+  schedule:
+    - cron: "37 3 * * 2"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false
+          annotations: true
+          persona: auditor


### PR DESCRIPTION
## Summary
- make actionlint a blocking check with `fail_level: any`
- add blocking zizmor workflow for GitHub Actions security analysis
- pin third-party actions to immutable SHAs and disable persisted checkout credentials
- add CODEOWNERS coverage for CI workflow metadata
- move GitHub expressions out of shell run bodies where zizmor flagged injection-prone patterns

## Validation
- `/tmp/codex-tools/actionlint/actionlint .github/workflows/*.yml`
- `/home/rger/.local/bin/zizmor --persona auditor .github`
- `/home/rger/.local/bin/yamllint -d '{extends: relaxed, rules: {line-length: {max: 120}}}' .github

With the help of AI Agent: Codex