### PR TITLE
[codex] Fix empty tag rulebase crash

### DIFF
--- a/src/samp.c
+++ b/src/samp.c
@@ -511,6 +511,8 @@ processTags(ln_ctx ctx, const char *buf, es_size_t lenBuf, es_size_t *poffs, str
 	while(i < lenBuf && buf[i] != ':') {
 		if(buf[i] == ',') {
 			/* end of this tag */
+			if(str == NULL)
+				goto done;
 			CHKR(addTagStrToBucket(ctx, str, tagBucket));
 			es_deleteStr(str);
 			str = NULL;
@@ -523,7 +525,7 @@ processTags(ln_ctx ctx, const char *buf, es_size_t lenBuf, es_size_t *poffs, str
 		++i;
 	}
 
-	if(buf[i] != ':')
+	if(i >= lenBuf || buf[i] != ':')
 		goto done;
 	++i; /* skip ':' */
 

--- a/src/v1_samp.c
+++ b/src/v1_samp.c
@@ -529,6 +529,8 @@ processTags(ln_ctx ctx, const char *buf, es_size_t lenBuf, es_size_t *poffs, str
 	while(i < lenBuf && buf[i] != ':') {
 		if(buf[i] == ',') {
 			/* end of this tag */
+			if(str == NULL)
+				goto done;
 			CHKR(addTagStrToBucket(ctx, str, tagBucket));
 			es_deleteStr(str);
 			str = NULL;
@@ -541,7 +543,7 @@ processTags(ln_ctx ctx, const char *buf, es_size_t lenBuf, es_size_t *poffs, str
 		++i;
 	}
 
-	if(buf[i] != ':')
+	if(i >= lenBuf || buf[i] != ':')
 		goto done;
 	++i; /* skip ':' */
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -42,6 +42,7 @@ TESTS_SHELLSCRIPTS = \
 	usrdef_ipaddr_dotdot2.sh \
 	usrdef_ipaddr_dotdot3.sh \
 	usrdef_nested_segfault.sh \
+	rule_empty_tag_segfault.sh \
 	missing_line_ending.sh \
 	lognormalizer-invld-call.sh \
 	string_rb_simple.sh \

--- a/tests/rule_empty_tag_segfault.sh
+++ b/tests/rule_empty_tag_segfault.sh
@@ -2,9 +2,10 @@
 # added 2026-05-05 by AI agent
 # This file is part of the liblognorm project, released under ASL 2.0
 
-. $srcdir/exec.sh
+# shellcheck source=tests/exec.sh disable=SC2154
+. "$srcdir"/exec.sh
 
-test_def $0 "empty v1 tag list entry is handled without segfault"
+test_def "$0" "empty v1 tag list entry is handled without segfault"
 
 add_rule 'rule=,'
 

--- a/tests/rule_empty_tag_segfault.sh
+++ b/tests/rule_empty_tag_segfault.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# added 2026-05-05 by AI agent
+# This file is part of the liblognorm project, released under ASL 2.0
+
+. $srcdir/exec.sh
+
+test_def $0 "empty v1 tag list entry is handled without segfault"
+
+add_rule 'rule=,'
+
+execute 'x'
+assert_output_json_eq '{ "originalmsg": "x", "unparsed-data": "x" }'
+
+cleanup_tmp_files

--- a/tests/rule_empty_tag_segfault.sh
+++ b/tests/rule_empty_tag_segfault.sh
@@ -2,7 +2,7 @@
 # added 2026-05-05 by AI agent
 # This file is part of the liblognorm project, released under ASL 2.0
 
-# shellcheck source=tests/exec.sh disable=SC2154
+# shellcheck source=tests/exec.sh disable=SC1091,SC2154
 . "$srcdir"/exec.sh
 
 test_def "$0" "empty v1 tag list entry is handled without segfault"


### PR DESCRIPTION
## Summary

Fix a rulebase-load crash when malformed v1 tag syntax contains an empty tag entry such as `rule=,`.

## Root Cause

`processTags` treated a comma as the end of a tag even when no tag text had been collected yet, then passed a null `es_str_t *` to `addTagStrToBucket`. The same parser also read `buf[i]` after walking to the end of the buffer.

## Changes

- Guard empty tag entries before adding them to the tag bucket.
- Check `i >= lenBuf` before testing for the tag terminator.
- Add `tests/rule_empty_tag_segfault.sh` as regression coverage.

Closes https://github.com/rsyslog/liblognorm/issues/327

## Validation

- `make -C compat`
- `make -C src ln_test`
- `make -C tests json_eq`
- `make -C tests check TESTS='rule_empty_tag_segfault.sh'`