### PR TITLE
[codex] Fix repeat while validation crash

### DIFF
--- a/src/pdag.c
+++ b/src/pdag.c
@@ -1375,6 +1375,14 @@ fixJSON(struct ln_pdag *dag,
 {
 	int r = LN_WRONGPARSER;
 
+	if(json == NULL) {
+		if(*value != NULL)
+			json_object_put(*value);
+		*value = NULL;
+		r = 0;
+		goto done;
+	}
+
 	if(prs->name ==  NULL) {
 		if (*value != NULL) {
 			/* Free the unneeded value */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -65,6 +65,7 @@ TESTS_SHELLSCRIPTS = \
 	repeat_mismatch_in_while.sh \
 	repeat_while_alternative.sh \
 	repeat_alternative_nested.sh \
+	repeat_named_while_segfault.sh \
 	repeat_name_dot.sh \
 	parser_prios.sh \
 	parser_whitespace.sh \

--- a/tests/repeat_named_while_segfault.sh
+++ b/tests/repeat_named_while_segfault.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# added 2026-05-05 by AI agent
+# This file is part of the liblognorm project, released under ASL 2.0
+
+# shellcheck source=tests/exec.sh disable=SC1091,SC2154
+. "$srcdir"/exec.sh
+
+test_def "$0" "repeat while clause with named parser does not segfault"
+
+add_rule 'version=2'
+add_rule 'rule=:a %
+        {"name":"numbers", "type":"repeat",
+            "parser":
+                     {"type":"number", "name":"n"},
+            "while":
+                     {"type":"char-to", "name":"host", "extradata":":"}
+         }% b'
+
+execute 'a 1 : 2 b'
+assert_output_json_eq '{ "originalmsg": "a 1 : 2 b", "unparsed-data": "1 : 2 b" }'
+
+cleanup_tmp_files


### PR DESCRIPTION
## Summary

Fix a repeat-parser crash when a `while` validation clause contains a named parser, such as `char-to` with `name` set.

## Root Cause

Repeat uses the `while` PDAG as a non-capturing validation check. A named parser inside that validation path can still produce a value, and `fixJSON` then attempted to attach that value to a null output JSON object.

## Changes

- Treat `json == NULL` in `fixJSON` as a non-capturing context and discard produced values.
- Add `tests/repeat_named_while_segfault.sh` as regression coverage.
- Leave parser semantics unchanged for the release fix; the archived sample still validates no-crash behavior rather than broadening `char-to` consumption rules.

Closes https://github.com/rsyslog/liblognorm/issues/355

## Validation

- `make -C compat`
- `make -C src ln_test`
- `make -C tests json_eq`
- `make -C tests check TESTS='repeat_named_while_segfault.sh repeat_very_simple.sh repeat_simple.sh repeat_mismatch_in_while.sh repeat_while_alternative.sh repeat_alternative_nested.sh repeat_name_dot.sh'`