### PR TITLE
Harden parsers against EOF inputs

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -1618,6 +1618,9 @@ PARSER_Parse(OpQuotedString)
 	c = npb->str;
 	i = *offs;
 
+	if(i == npb->strLen)
+		goto done;
+
 	if(c[i] != '"') {
 		while(i < npb->strLen && c[i] != ' ')
 			i++;
@@ -2663,7 +2666,10 @@ PARSER_Parse(JSON)
 	struct json_tokener *tokener = NULL;
 	struct data_JSON *const data = (struct data_JSON*) pdata;
 
-	if(npb->str[i] != '{' && npb->str[i] != ']') {
+	if(i == npb->strLen)
+		goto done;
+
+	if(npb->str[i] != '{' && npb->str[i] != '[') {
 		/* this can't be json, see RFC4627, Sect. 2
 		 * see this bug in json-c:
 		 * https://github.com/json-c/json-c/issues/181
@@ -3515,7 +3521,7 @@ PARSER_Parse(CheckpointLEA)
 			FAIL(LN_WRONGPARSER);
 		}
 		/* Sometimes there is multiple colons */
-		while( i < npb->strLen && npb->str[i+1] == ':' ) {
+		while( i + 1 < npb->strLen && npb->str[i+1] == ':' ) {
 			i++;
 		}
 		lenName = i - iName;
@@ -3524,6 +3530,8 @@ PARSER_Parse(CheckpointLEA)
 		while(i < npb->strLen && npb->str[i] == ' ') { /* skip leading SP */
 			++i;
 		}
+		if(i == npb->strLen)
+			FAIL(LN_WRONGPARSER);
 		/* Improvement by KGuillemot & M4jr0 to support quoted values */
 		if( npb->str[i] == '"' ) {
 			int continuous_backslash = 0;
@@ -3539,6 +3547,8 @@ PARSER_Parse(CheckpointLEA)
 			}
 			// Do not take the " in value
 			lenValue = i - iValue;
+			if(i == npb->strLen)
+				FAIL(LN_WRONGPARSER);
 			// Skip "
 			++i;
 		} else {
@@ -3556,7 +3566,7 @@ PARSER_Parse(CheckpointLEA)
 			++i;
 		}
 
-		if(i+1 > npb->strLen || (npb->str[i] != ';' && npb->str[i] != data->terminator))
+		if(i >= npb->strLen || (npb->str[i] != ';' && npb->str[i] != data->terminator))
 			FAIL(LN_WRONGPARSER);
 
 		if(npb->str[i] == ';')
@@ -4003,7 +4013,7 @@ PARSER_Parse(String)
 
 	if((i - *offs < 1) || (data->matching == ST_MATCH_EXACT)) {
 		const size_t trmChkIdx = (bHaveQuotes) ? i+1 : i;
-		if(npb->str[trmChkIdx] != ' ' && trmChkIdx != npb->strLen)
+		if(trmChkIdx != npb->strLen && npb->str[trmChkIdx] != ' ')
 			goto done;
 	}
 

--- a/src/v1_parser.c
+++ b/src/v1_parser.c
@@ -1852,6 +1852,9 @@ PARSER(OpQuotedString)
 	c = str;
 	i = *offs;
 
+	if(i == strLen)
+		goto done;
+
 	if(c[i] != '"') {
 		while(i < strLen && c[i] != ' ')
 			i++;
@@ -2574,7 +2577,10 @@ PARSER(JSON)
 	const size_t i = *offs;
 	struct json_tokener *tokener = NULL;
 
-	if(str[i] != '{' && str[i] != ']') {
+	if(i == strLen)
+		goto done;
+
+	if(str[i] != '{' && str[i] != '[') {
 		/* this can't be json, see RFC4627, Sect. 2
 		 * see this bug in json-c:
 		 * https://github.com/json-c/json-c/issues/181
@@ -3169,6 +3175,8 @@ PARSER(CheckpointLEA)
 
 		while(i < strLen && str[i] == ' ') /* skip leading SP */
 			++i;
+		if(i == strLen)
+			FAIL(LN_WRONGPARSER);
 		if(str[i] == '"') {
 			int continuous_backslash = 0;
 			iValue = i + 1;
@@ -3192,7 +3200,7 @@ PARSER(CheckpointLEA)
 			}
 			lenValue = i - iValue;
 		}
-		if(i+1 > strLen || str[i] != ';')
+		if(i >= strLen || str[i] != ';')
 			FAIL(LN_WRONGPARSER);
 		++i; /* skip ';' */
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -67,6 +67,7 @@ TESTS_SHELLSCRIPTS = \
 	repeat_alternative_nested.sh \
 	repeat_named_while_segfault.sh \
 	repeat_name_dot.sh \
+	parser_eof_hardening.sh \
 	parser_prios.sh \
 	parser_whitespace.sh \
 	parser_whitespace_jsoncnf.sh \
@@ -161,6 +162,9 @@ TESTS_SHELLSCRIPTS += \
 	field_cisco-interface-spec-at-EOL.sh \
 	field_float_with_invalid_ruledef.sh \
 	very_long_logline.sh
+
+TESTS_SHELLSCRIPTS += \
+	parser_eof_hardening_v1.sh
 
 
 #re-add to TESTS if needed: user_test

--- a/tests/parser_eof_hardening.sh
+++ b/tests/parser_eof_hardening.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# added 2026-05-06 by AI agent
+# This file is part of the liblognorm project, released under ASL 2.0
+# shellcheck source=tests/exec.sh disable=SC1091,SC2154
+. "$srcdir"/exec.sh
+
+test_def "$0" "v2 parsers handle EOF safely"
+
+add_rule 'version=2'
+add_rule 'rule=:%f:string%'
+execute 'abc'
+assert_output_json_eq '{ "f": "abc" }'
+
+reset_rules
+add_rule 'version=2'
+add_rule 'rule=:pre%f:json%'
+execute 'pre'
+assert_output_json_eq '{ "originalmsg": "pre", "unparsed-data": "" }'
+
+reset_rules
+add_rule 'version=2'
+add_rule 'rule=:%f:json%'
+execute '[1,2]'
+assert_output_json_eq '{ "f": [ 1, 2 ] }'
+
+reset_rules
+add_rule 'version=2'
+add_rule 'rule=:pre%f:op-quoted-string%'
+execute 'pre'
+assert_output_json_eq '{ "originalmsg": "pre", "unparsed-data": "" }'
+
+reset_rules
+add_rule 'version=2'
+add_rule 'rule=:%f:checkpoint-lea%'
+execute 'src:   '
+assert_output_json_eq '{ "originalmsg": "src:   ", "unparsed-data": "src:   " }'
+
+execute 'src: "unterminated'
+assert_output_json_eq '{ "originalmsg": "src: \"unterminated", "unparsed-data": "src: \"unterminated" }'
+
+execute 'src::'
+assert_output_json_eq '{ "originalmsg": "src::", "unparsed-data": "src::" }'
+
+cleanup_tmp_files

--- a/tests/parser_eof_hardening_v1.sh
+++ b/tests/parser_eof_hardening_v1.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# added 2026-05-06 by AI agent
+# This file is part of the liblognorm project, released under ASL 2.0
+# shellcheck source=tests/exec.sh disable=SC1091,SC2154
+. "$srcdir"/exec.sh
+
+test_def "$0" "v1 parsers handle EOF safely"
+
+add_rule 'rule=:pre%f:json%'
+execute 'pre'
+assert_output_json_eq '{ "originalmsg": "pre", "unparsed-data": "" }'
+
+reset_rules
+add_rule 'rule=:%f:json%'
+execute '[1,2]'
+assert_output_json_eq '{ "f": [ 1, 2 ] }'
+
+reset_rules
+add_rule 'rule=:pre%f:op-quoted-string%'
+execute 'pre'
+assert_output_json_eq '{ "originalmsg": "pre", "unparsed-data": "" }'
+
+reset_rules
+add_rule 'rule=:%f:checkpoint-lea%'
+execute 'src:   '
+assert_output_json_eq '{ "originalmsg": "src:   ", "unparsed-data": "src:   " }'
+
+cleanup_tmp_files


### PR DESCRIPTION
## Summary
- Guard low-risk v2 parser EOF/OOB paths for op-quoted-string, json, checkpoint-lea, and string.
- Guard low-risk v1 parser EOF/OOB paths for op-quoted-string, json, and checkpoint-lea.
- Fix the JSON opener precheck from `]` to `[` and add focused EOF regression scripts.

## Validation
- `autoreconf -fvi`
- `./configure`
- `make -C src ln_test` (passed after building `compat/compat.la` in the fresh worktree)
- `make -C tests TESTS='parser_eof_hardening.sh parser_eof_hardening_v1.sh' check`
- `ai/run-parser-family.sh json`
- `ai/run-parser-family.sh op-quoted-string` (no matching `field_op-quoted-string*.sh` family)
- `ai/run-parser-family.sh op_quoted_string`
- `ai/run-parser-family.sh checkpoint-lea`
- `ai/run-parser-family.sh string`
- `make check`