### PR TITLE
Clarify public header contract for 2.1.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,8 +9,8 @@ Version 2.1.0, 2026-05-07
   - fast result structure (typed fields, zero JSON overhead)
   - snapshot support for async consumers (rsyslog worker queues)
   - automatic fallback to recursive walker on compilation failure
-  New API: ln_turbo_normalize(), ln_fast_result_get_string/int(),
-  ln_turbo_snapshot_result(). New context option: LN_CTXOPT_TURBO.
+  New API: LN_CTXOPT_TURBO and ln_normalize_to_str().
+  TurboVM implementation headers and raw fast-result helpers remain internal.
   Enabled via: ./configure --enable-turbo
   Contributed by Jérémie Jourdin / Advens.
 - pcre2 used instead of pcre (which is no longer supported)

--- a/doc/pdag_implementation_model.rst
+++ b/doc/pdag_implementation_model.rst
@@ -96,6 +96,7 @@ Given a node ``n`` and suffix ``s``:
 
 1. If ``s`` is empty: succeed only if ``n`` is terminal.
 2. Otherwise, iterate over ``n``'s outgoing edges **in priority order**:
+
    - If an edge matches a prefix of ``s``, recurse into its destination with the
      remaining suffix. Extraction happens only if the recursive call succeeds.
    - On failure, discard any partial extraction from that attempt and continue

--- a/doc/turbo.rst
+++ b/doc/turbo.rst
@@ -74,12 +74,6 @@ on the normalization context before loading rules::
     ln_setCtxOpts(ctx, LN_CTXOPT_TURBO);
     ln_loadSamples(ctx, "/path/to/rules.rb");
 
-After loading, verify that compilation succeeded::
-
-    if (ln_turbo_is_available(ctx)) {
-        /* TurboVM ready — ln_normalize() will use the fast path */
-    }
-
 For direct string output (bypassing json-c entirely)::
 
     char *json_str = NULL;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -56,7 +56,7 @@ liblognorm_la_LIBADD = $(rt_libs) $(JSON_C_LIBS) $(LIBESTR_LIBS) $(PCRE_LIBS) -l
 # info on version-info:
 # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 # Note: v2 now starts at version 5, as v1 previously also had 4
-liblognorm_la_LDFLAGS = -version-info 6:0:1
+liblognorm_la_LDFLAGS = -version-info 7:0:2
 
 # Public API
 include_HEADERS = liblognorm.h lognorm-features.h
@@ -85,6 +85,4 @@ liblognorm_la_SOURCES += \
 	turbo_snapshot.c \
 	turbo_snapshot.h
 liblognorm_la_CPPFLAGS += $(TURBO_CFLAGS)
-include_HEADERS += turbo.h turbo_result.h turbo_result_fast.h \
-	turbo_arena.h turbo_snapshot.h turbo_opcode.h
 endif


### PR DESCRIPTION
## Summary
- keep TurboVM implementation headers internal and stop installing them in --enable-turbo builds
- document the 2.1.0 public Turbo API as LN_CTXOPT_TURBO and ln_normalize_to_str()
- bump libtool version-info for the new public symbols and fix a Sphinx warning in the PDAG notes

## Validation
- rsyslog integration helper passed against installed headers: 11/11 normalize tests
- CI-style Turbo build passed with CFLAGS=-g --enable-turbo --enable-regexp: 141/141
- verified --enable-turbo install only ships liblognorm.h and lognorm-features.h
- make -C doc html passed
- make distcheck passed

Note: maintainer warning-policy builds still hit the existing GCC -Winline-as-error issue in TurboVM; per release discussion, this is intentionally not addressed here.