### PR TITLE
Suppress inline advisory warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@ AC_PROG_LIBTOOL
 m4_ifdef([AX_IS_RELEASE], [
 	AX_IS_RELEASE([git-directory])
 	m4_ifdef([AX_COMPILER_FLAGS], [
-		AX_COMPILER_FLAGS()
+		AX_COMPILER_FLAGS([], [], [], [], [-Wno-inline])
 	], [
 		if test "$GCC" = "yes"
 		then CFLAGS="$CFLAGS -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute -g"


### PR DESCRIPTION
## Summary
- suppress GCC/Clang inline advisory warnings via the existing AX_COMPILER_FLAGS path
- keep valid static inline header helpers intact instead of treating compiler inline decisions as correctness failures
- rely on the macro's compiler probing so unsupported warning flags are not added, and -Wno-error=inline is added when available

## Rationale
static inline helpers in headers are valid without a separate external fallback: if the compiler does not inline, it may emit a translation-unit-local function. The issue here is only that -Winline is advisory and becomes fatal under -Werror.

For Turbo integration, this keeps the current helper shape while avoiding making inline success part of the build contract. Public API decisions for rsyslog should remain separate from this warning policy cleanup.

## Validation
- autoreconf -fiv
- ./configure --enable-regexp --enable-turbo
- make -j4
- make check: 141/141 passing