### PR TITLE
turbo: curated public header (lognorm-turbo.h) + name-value-list ignore_whitespaces

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,8 +9,13 @@ Version 2.1.0, 2026-05-07
   - fast result structure (typed fields, zero JSON overhead)
   - snapshot support for async consumers (rsyslog worker queues)
   - automatic fallback to recursive walker on compilation failure
-  New API: ln_turbo_normalize(), ln_fast_result_get_string/int(),
-  ln_turbo_snapshot_result(). New context option: LN_CTXOPT_TURBO.
+  New context option: LN_CTXOPT_TURBO. The simple path is available
+  through liblognorm.h (ln_normalize() / ln_normalize_to_str()).
+  High-performance consumers use the curated, opaque public header
+  lognorm-turbo.h (raw fast-result access via ln_turbo_normalize_raw(),
+  snapshots via ln_turbo_snapshot_result(), and typed field accessors
+  including ln_fast_result_get_field_typed()). The TurboVM implementation
+  headers (turbo*.h) remain internal and are not installed.
   Enabled via: ./configure --enable-turbo
   Contributed by Jérémie Jourdin / Advens.
 - pcre2 used instead of pcre (which is no longer supported)

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,6 +9,8 @@ Version 2.1.0, 2026-05-07
   - fast result structure (typed fields, zero JSON overhead)
   - snapshot support for async consumers (rsyslog worker queues)
   - automatic fallback to recursive walker on compilation failure
+  - name-value-list honors the ignore_whitespaces option, matching the
+    standard parser
   New context option: LN_CTXOPT_TURBO. The simple path is available
   through liblognorm.h (ln_normalize() / ln_normalize_to_str()).
   High-performance consumers use the curated, opaque public header

--- a/doc/pdag_implementation_model.rst
+++ b/doc/pdag_implementation_model.rst
@@ -96,6 +96,7 @@ Given a node ``n`` and suffix ``s``:
 
 1. If ``s`` is empty: succeed only if ``n`` is terminal.
 2. Otherwise, iterate over ``n``'s outgoing edges **in priority order**:
+
    - If an edge matches a prefix of ``s``, recurse into its destination with the
      remaining suffix. Extraction happens only if the recursive call succeeds.
    - On failure, discard any partial extraction from that attempt and continue

--- a/doc/turbo.rst
+++ b/doc/turbo.rst
@@ -94,6 +94,34 @@ The standard ``ln_normalize()`` function also benefits from TurboVM
 when it is enabled — the bytecode engine is used internally, with
 automatic fallback to the recursive walker if needed.
 
+High-performance API (lognorm-turbo.h)
+--------------------------------------
+
+Consumers that want to avoid json-c construction entirely (for example
+rsyslog's ``mmnormalize`` worker hot path) can use the curated public
+header ``lognorm-turbo.h``. It is installed alongside ``liblognorm.h``
+and ``lognorm-features.h`` and gated on ``LOGNORM_TURBO_SUPPORTED``::
+
+    #include <liblognorm/lognorm-features.h>
+    #if defined(LOGNORM_TURBO_SUPPORTED)
+    #include <liblognorm/lognorm-turbo.h>
+    #endif
+
+The header exposes only opaque types and a function-level contract; the
+internal ``turbo*.h`` headers and the fast-result/snapshot struct layouts
+are **not** installed and may change between releases without affecting the
+ABI. The contract covers:
+
+- ``ln_turbo_normalize_raw()`` — normalize into an opaque, context-owned
+  result (valid until the next normalize call on that context);
+- ``ln_turbo_snapshot_result()`` / ``ln_fast_result_snapshot_get()`` /
+  ``ln_fast_result_snapshot_free()`` — retain a result beyond the next call;
+- typed accessors ``ln_fast_result_field_count()``,
+  ``ln_fast_result_get_field()``, ``ln_fast_result_get_field_typed()``
+  (preserves ``LN_FTYPE_*`` value type and the ``LN_FFIELD_NESTED`` flag),
+  ``ln_fast_result_get_string()`` / ``_get_int()``, the tag accessors and
+  ``ln_fast_result_get_rule_id()``.
+
 Supported Parsers
 -----------------
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -60,8 +60,10 @@ liblognorm_la_LIBADD = $(rt_libs) $(JSON_C_LIBS) $(LIBESTR_LIBS) $(PCRE_LIBS) -l
 # soname stays liblognorm.so.5 (current-age), interface revision bumped.
 liblognorm_la_LDFLAGS = -version-info 7:0:2
 
-# Public API
-include_HEADERS = liblognorm.h lognorm-features.h
+# Public API.  lognorm-turbo.h is installed unconditionally — it provides no-op
+# stubs when Turbo is disabled, so consumers can include it against any build.
+# Only the implementation sources stay behind ENABLE_TURBO (below).
+include_HEADERS = liblognorm.h lognorm-features.h lognorm-turbo.h
 
 # TurboVM bytecode engine (optional, SIMD-accelerated log parsing)
 if ENABLE_TURBO
@@ -85,9 +87,6 @@ liblognorm_la_SOURCES += \
 	turbo_json_fast.h \
 	turbo_json_impl.c \
 	turbo_snapshot.c \
-	turbo_snapshot.h \
-	lognorm-turbo.h
+	turbo_snapshot.h
 liblognorm_la_CPPFLAGS += $(TURBO_CFLAGS)
-# Only the curated, opaque public header is installed; turbo*.h stay internal.
-include_HEADERS += lognorm-turbo.h
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -56,7 +56,9 @@ liblognorm_la_LIBADD = $(rt_libs) $(JSON_C_LIBS) $(LIBESTR_LIBS) $(PCRE_LIBS) -l
 # info on version-info:
 # http://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html
 # Note: v2 now starts at version 5, as v1 previously also had 4
-liblognorm_la_LDFLAGS = -version-info 6:0:1
+# 2.1.0: +1 current/+age for the new public Turbo API (lognorm-turbo.h);
+# soname stays liblognorm.so.5 (current-age), interface revision bumped.
+liblognorm_la_LDFLAGS = -version-info 7:0:2
 
 # Public API
 include_HEADERS = liblognorm.h lognorm-features.h
@@ -83,8 +85,9 @@ liblognorm_la_SOURCES += \
 	turbo_json_fast.h \
 	turbo_json_impl.c \
 	turbo_snapshot.c \
-	turbo_snapshot.h
+	turbo_snapshot.h \
+	lognorm-turbo.h
 liblognorm_la_CPPFLAGS += $(TURBO_CFLAGS)
-include_HEADERS += turbo.h turbo_result.h turbo_result_fast.h \
-	turbo_arena.h turbo_snapshot.h turbo_opcode.h
+# Only the curated, opaque public header is installed; turbo*.h stay internal.
+include_HEADERS += lognorm-turbo.h
 endif

--- a/src/lognorm-turbo.h
+++ b/src/lognorm-turbo.h
@@ -26,14 +26,19 @@
 
 /* Turbo availability is published by lognorm-features.h, which liblognorm
  * installs alongside this header and generates with LOGNORM_TURBO_SUPPORTED set
- * to match the build.  Include it unconditionally so a consumer's own
- * HAVE_CONFIG_H (pulling in their config.h) can never hide an installed
- * Turbo-enabled library.  When building liblognorm itself, config.h
- * additionally provides ENABLE_TURBO. */
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
+ * to match the build.  This is a public installed header, so it must NOT pull
+ * in the private build-time config.h: doing so would leak liblognorm's private
+ * PACKAGE and HAVE_xxx macros into a consumer, or shadow them with the
+ * consumer's own config.h.  Availability comes solely from the installed
+ * lognorm-features.h; liblognorm's own .c files include config.h (for
+ * ENABLE_TURBO) before this header. */
 #include "lognorm-features.h"
+
+/* Opaque liblognorm context.  Forward-declared as an incomplete struct rather
+ * than re-typedef'd to `ln_ctx`: liblognorm.h owns that typedef, and repeating
+ * it here is ill-formed under strict C99 when both public headers are included.
+ * Callers obtain a context from ln_initCtx() (liblognorm.h) and pass it here. */
+struct ln_ctx_s;
 
 #if defined(ENABLE_TURBO) || defined(LOGNORM_TURBO_SUPPORTED)
 
@@ -44,9 +49,7 @@
 extern "C" {
 #endif
 
-/* Forward declaration of the liblognorm context (also typedef'd, identically,
- * in liblognorm.h — a redundant typedef is permitted and harmless). */
-typedef struct ln_ctx_s *ln_ctx;
+/* (ln_ctx context type: see the struct ln_ctx_s forward-declaration above.) */
 
 /*============================================================================
  * Opaque types
@@ -86,7 +89,7 @@ typedef enum {
  * Check whether a compiled TurboVM program is available for this context.
  * @return non-zero if turbo normalization can be used, 0 otherwise.
  */
-int ln_turbo_is_available(ln_ctx ctx);
+int ln_turbo_is_available(struct ln_ctx_s *ctx);
 
 /*============================================================================
  * Normalization
@@ -102,7 +105,7 @@ int ln_turbo_is_available(ln_ctx ctx);
  * @param json_len  receives the JSON string length
  * @return 0 on match, negative on no-match/error.
  */
-int ln_turbo_normalize_to_str(ln_ctx ctx, const char *str, size_t strLen,
+int ln_turbo_normalize_to_str(struct ln_ctx_s *ctx, const char *str, size_t strLen,
 							  char **json_str, size_t *json_len);
 
 /**
@@ -118,7 +121,7 @@ int ln_turbo_normalize_to_str(ln_ctx ctx, const char *str, size_t strLen,
  * @param result  receives a pointer to the (opaque) result
  * @return 0 on match, negative on no-match/error.
  */
-int ln_turbo_normalize_raw(ln_ctx ctx, const char *str, size_t strLen,
+int ln_turbo_normalize_raw(struct ln_ctx_s *ctx, const char *str, size_t strLen,
 						   const ln_fast_result_t **result);
 
 /*============================================================================
@@ -194,7 +197,7 @@ const char *ln_fast_result_get_rule_id(const ln_fast_result_t *r);
  *
  * @return snapshot (free with ln_fast_result_snapshot_free), or NULL on error.
  */
-ln_fast_result_snapshot_t *ln_turbo_snapshot_result(ln_ctx ctx);
+ln_fast_result_snapshot_t *ln_turbo_snapshot_result(struct ln_ctx_s *ctx);
 
 /**
  * Get the result held by a snapshot. Valid for the snapshot's lifetime and
@@ -215,7 +218,6 @@ void ln_fast_result_snapshot_free(ln_fast_result_snapshot_t *snap);
 /* No-op stubs mirroring the full public surface, so consumers can compile and
  * link unconditionally even when TurboVM is not built. Calls in conditional
  * (runtime-disabled but still compiled) blocks degrade to error/empty values. */
-typedef struct ln_ctx_s *ln_ctx;
 typedef void *ln_fast_result_t;
 typedef void *ln_fast_result_snapshot_t;
 

--- a/src/lognorm-turbo.h
+++ b/src/lognorm-turbo.h
@@ -24,13 +24,16 @@
 #ifndef LIBLOGNORM_LOGNORM_TURBO_H_INCLUDED
 #define	LIBLOGNORM_LOGNORM_TURBO_H_INCLUDED
 
-/* When building liblognorm itself, config.h provides ENABLE_TURBO.
- * External consumers pull the installed feature macros instead. */
+/* Turbo availability is published by lognorm-features.h, which liblognorm
+ * installs alongside this header and generates with LOGNORM_TURBO_SUPPORTED set
+ * to match the build.  Include it unconditionally so a consumer's own
+ * HAVE_CONFIG_H (pulling in their config.h) can never hide an installed
+ * Turbo-enabled library.  When building liblognorm itself, config.h
+ * additionally provides ENABLE_TURBO. */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
-#else
-#include "lognorm-features.h"
 #endif
+#include "lognorm-features.h"
 
 #if defined(ENABLE_TURBO) || defined(LOGNORM_TURBO_SUPPORTED)
 

--- a/src/lognorm-turbo.h
+++ b/src/lognorm-turbo.h
@@ -1,0 +1,225 @@
+/**
+ * @file lognorm-turbo.h
+ * @brief Public API for the TurboVM bytecode normalization engine.
+ *
+ * This is the ONLY Turbo header that liblognorm installs (alongside
+ * liblognorm.h and lognorm-features.h). It exposes an opaque,
+ * function-level contract: no internal struct layouts cross the library
+ * boundary, so the fast-result/snapshot representation, inline buffer
+ * sizes and field limits remain free to change without breaking the ABI.
+ *
+ * Availability is gated on LOGNORM_TURBO_SUPPORTED (from lognorm-features.h)
+ * for external consumers, and on ENABLE_TURBO when building liblognorm
+ * itself. When neither is defined, the symbols degrade to no-op stubs so
+ * consumers can compile unconditionally.
+ *
+ * The internal headers (turbo.h, turbo_result_fast.h, turbo_snapshot.h, ...)
+ * remain private and are not installed.
+ *//*
+ * Copyright 2024-2026 by Advens and Jeremie Jourdin.
+ * Copyright 2015-2026 by Rainer Gerhards and Adiscon GmbH.
+ *
+ * Released under ASL 2.0.
+ */
+#ifndef LIBLOGNORM_LOGNORM_TURBO_H_INCLUDED
+#define	LIBLOGNORM_LOGNORM_TURBO_H_INCLUDED
+
+/* When building liblognorm itself, config.h provides ENABLE_TURBO.
+ * External consumers pull the installed feature macros instead. */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#else
+#include "lognorm-features.h"
+#endif
+
+#if defined(ENABLE_TURBO) || defined(LOGNORM_TURBO_SUPPORTED)
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Forward declaration of the liblognorm context (also typedef'd, identically,
+ * in liblognorm.h — a redundant typedef is permitted and harmless). */
+typedef struct ln_ctx_s *ln_ctx;
+
+/*============================================================================
+ * Opaque types
+ *
+ * Declared as incomplete types: callers only ever hold pointers. The full
+ * definitions live in the private headers and never reach installed code.
+ *============================================================================*/
+
+typedef struct ln_fast_result_s          ln_fast_result_t;
+typedef struct ln_fast_result_snapshot_s ln_fast_result_snapshot_t;
+
+/*============================================================================
+ * Field value types
+ *
+ * Returned via ln_fast_result_get_field_typed(). The enum is part of the
+ * public contract; the numeric values are stable.
+ *============================================================================*/
+
+typedef enum {
+	LN_FTYPE_NULL = 0,
+	LN_FTYPE_STRING,        /**< String value (ptr + len)        */
+	LN_FTYPE_STRING_INLINE, /**< String value (inline-stored)    */
+	LN_FTYPE_INT,           /**< Signed 64-bit integer           */
+	LN_FTYPE_DOUBLE,        /**< Double-precision float          */
+	LN_FTYPE_BOOL           /**< Boolean (reported as int 0/1)   */
+} ln_ftype_t;
+
+/** Field flag: the field name is dotted and denotes a nested object
+ *  (e.g. "a.b" -> {"a":{"b":...}}). Other flag bits are private. */
+#define LN_FFIELD_NESTED 0x04
+
+/*============================================================================
+ * Availability
+ *============================================================================*/
+
+/**
+ * Check whether a compiled TurboVM program is available for this context.
+ * @return non-zero if turbo normalization can be used, 0 otherwise.
+ */
+int ln_turbo_is_available(ln_ctx ctx);
+
+/*============================================================================
+ * Normalization
+ *============================================================================*/
+
+/**
+ * Normalize using the TurboVM and emit a JSON string.
+ *
+ * @param ctx       liblognorm context
+ * @param str       input to normalize
+ * @param strLen    length of @p str
+ * @param json_str  receives a newly allocated JSON string (caller frees)
+ * @param json_len  receives the JSON string length
+ * @return 0 on match, negative on no-match/error.
+ */
+int ln_turbo_normalize_to_str(ln_ctx ctx, const char *str, size_t strLen,
+							  char **json_str, size_t *json_len);
+
+/**
+ * Normalize using the TurboVM with direct (zero-JSON) result access.
+ *
+ * The result is owned by the turbo context and remains valid only until the
+ * next normalize call on the same context. Do not free it. To retain it
+ * across calls, take a snapshot (see below).
+ *
+ * @param ctx     liblognorm context
+ * @param str     input to normalize
+ * @param strLen  length of @p str
+ * @param result  receives a pointer to the (opaque) result
+ * @return 0 on match, negative on no-match/error.
+ */
+int ln_turbo_normalize_raw(ln_ctx ctx, const char *str, size_t strLen,
+						   const ln_fast_result_t **result);
+
+/*============================================================================
+ * Result accessors
+ *============================================================================*/
+
+/** Number of fields in the result. */
+int ln_fast_result_field_count(const ln_fast_result_t *r);
+
+/**
+ * Get a field by index as a string.
+ *
+ * Non-string fields yield a NULL value with zero length; use
+ * ln_fast_result_get_field_typed() to read their typed value.
+ *
+ * @return 0 on success, -1 if @p idx is out of range.
+ */
+int ln_fast_result_get_field(const ln_fast_result_t *r, int idx,
+							 const char **name, size_t *nlen,
+							 const char **value, size_t *vlen);
+
+/**
+ * Get a field by index, preserving its value type.
+ *
+ * Lets callers build correctly-typed output (JSON numbers/booleans, nested
+ * objects) without peeking at the internal result layout. Exactly one value
+ * out-param is populated, selected by @p type:
+ *   - LN_FTYPE_STRING / LN_FTYPE_STRING_INLINE -> @p sval / @p slen
+ *   - LN_FTYPE_INT / LN_FTYPE_BOOL             -> @p ival (BOOL is 0 or 1)
+ *   - LN_FTYPE_DOUBLE                          -> @p dval
+ *   - LN_FTYPE_NULL                            -> none
+ *
+ * @p flags receives the public field flags (test against LN_FFIELD_NESTED).
+ * Any out-param may be NULL if the caller is not interested in it.
+ *
+ * @return 0 on success, -1 if @p idx is out of range.
+ */
+int ln_fast_result_get_field_typed(const ln_fast_result_t *r, int idx,
+								   const char **name, size_t *nlen,
+								   unsigned *type, unsigned *flags,
+								   const char **sval, size_t *slen,
+								   int64_t *ival, double *dval);
+
+/** Find a string field by name. @return 0 if found, -1 otherwise. */
+int ln_fast_result_get_string(const ln_fast_result_t *r, const char *name,
+							  const char **value, size_t *vlen);
+
+/** Find an integer field by name. @return 0 if found, -1 otherwise. */
+int ln_fast_result_get_int(const ln_fast_result_t *r, const char *name,
+						   int64_t *value);
+
+/** Number of tags in the result. */
+int ln_fast_result_tag_count(const ln_fast_result_t *r);
+
+/** Get a tag by index, or NULL if @p idx is out of range. */
+const char *ln_fast_result_get_tag(const ln_fast_result_t *r, int idx);
+
+/** @return 1 if @p tag is present, 0 otherwise. */
+int ln_fast_result_has_tag(const ln_fast_result_t *r, const char *tag);
+
+/** Matched rule ID, or NULL if there was no match. */
+const char *ln_fast_result_get_rule_id(const ln_fast_result_t *r);
+
+/*============================================================================
+ * Snapshots (retain a result beyond the next normalize call)
+ *============================================================================*/
+
+/**
+ * Snapshot the current turbo result into a self-contained, caller-owned copy.
+ *
+ * Must be called after a successful ln_turbo_normalize_raw() and before the
+ * next normalize call on the same context.
+ *
+ * @return snapshot (free with ln_fast_result_snapshot_free), or NULL on error.
+ */
+ln_fast_result_snapshot_t *ln_turbo_snapshot_result(ln_ctx ctx);
+
+/**
+ * Get the result held by a snapshot. Valid for the snapshot's lifetime and
+ * usable with every ln_fast_result_* accessor above.
+ */
+const ln_fast_result_t *
+ln_fast_result_snapshot_get(const ln_fast_result_snapshot_t *snap);
+
+/** Free a snapshot (single free, NULL-safe). */
+void ln_fast_result_snapshot_free(ln_fast_result_snapshot_t *snap);
+
+#ifdef __cplusplus
+}
+#endif
+
+#else /* !ENABLE_TURBO && !LOGNORM_TURBO_SUPPORTED */
+
+/* No-op stubs so consumers can compile unconditionally. */
+typedef void *ln_fast_result_t;
+typedef void *ln_fast_result_snapshot_t;
+
+#define ln_turbo_is_available(ctx)                        (0)
+#define ln_turbo_normalize_to_str(ctx, str, len, js, jl)  (-1)
+#define ln_turbo_normalize_raw(ctx, str, len, r)          (-1)
+#define ln_turbo_snapshot_result(ctx)                     ((void *)0)
+#define ln_fast_result_snapshot_get(snap)                 ((void *)0)
+#define ln_fast_result_snapshot_free(snap)                ((void)(snap))
+
+#endif /* ENABLE_TURBO || LOGNORM_TURBO_SUPPORTED */
+
+#endif /* LIBLOGNORM_LOGNORM_TURBO_H_INCLUDED */

--- a/src/lognorm-turbo.h
+++ b/src/lognorm-turbo.h
@@ -209,13 +209,36 @@ void ln_fast_result_snapshot_free(ln_fast_result_snapshot_t *snap);
 
 #else /* !ENABLE_TURBO && !LOGNORM_TURBO_SUPPORTED */
 
-/* No-op stubs so consumers can compile unconditionally. */
+/* No-op stubs mirroring the full public surface, so consumers can compile and
+ * link unconditionally even when TurboVM is not built. Calls in conditional
+ * (runtime-disabled but still compiled) blocks degrade to error/empty values. */
+typedef struct ln_ctx_s *ln_ctx;
 typedef void *ln_fast_result_t;
 typedef void *ln_fast_result_snapshot_t;
+
+typedef enum {
+	LN_FTYPE_NULL = 0,
+	LN_FTYPE_STRING,
+	LN_FTYPE_STRING_INLINE,
+	LN_FTYPE_INT,
+	LN_FTYPE_DOUBLE,
+	LN_FTYPE_BOOL
+} ln_ftype_t;
+
+#define LN_FFIELD_NESTED 0x04
 
 #define ln_turbo_is_available(ctx)                        (0)
 #define ln_turbo_normalize_to_str(ctx, str, len, js, jl)  (-1)
 #define ln_turbo_normalize_raw(ctx, str, len, r)          (-1)
+#define ln_fast_result_field_count(r)                     (0)
+#define ln_fast_result_get_field(r, idx, name, nlen, val, vlen)  (-1)
+#define ln_fast_result_get_field_typed(r, idx, name, nlen, type, flags, sval, slen, ival, dval)  (-1)
+#define ln_fast_result_get_string(r, name, val, vlen)     (-1)
+#define ln_fast_result_get_int(r, name, val)              (-1)
+#define ln_fast_result_tag_count(r)                       (0)
+#define ln_fast_result_get_tag(r, idx)                    ((const char *)0)
+#define ln_fast_result_has_tag(r, tag)                    (0)
+#define ln_fast_result_get_rule_id(r)                     ((const char *)0)
 #define ln_turbo_snapshot_result(ctx)                     ((void *)0)
 #define ln_fast_result_snapshot_get(snap)                 ((void *)0)
 #define ln_fast_result_snapshot_free(snap)                ((void)(snap))

--- a/src/lognorm-turbo.h
+++ b/src/lognorm-turbo.h
@@ -228,8 +228,11 @@ void ln_fast_result_snapshot_free(ln_fast_result_snapshot_t *snap);
  * stubs use their parameters (cast to void) and mirror the real signatures, so
  * consumer code compiles identically whether or not TurboVM is present. */
 
-typedef void *ln_fast_result_t;
-typedef void *ln_fast_result_snapshot_t;
+/* Same incomplete struct types as the real branch above, so the opaque handles
+ * are type-identical in both build configurations (a consumer cannot silently
+ * cross the void* boundary). They are only ever held as pointers. */
+typedef struct ln_fast_result_s          ln_fast_result_t;
+typedef struct ln_fast_result_snapshot_s ln_fast_result_snapshot_t;
 
 typedef enum {
 	LN_FTYPE_NULL = 0,

--- a/src/lognorm-turbo.h
+++ b/src/lognorm-turbo.h
@@ -40,10 +40,13 @@
  * Callers obtain a context from ln_initCtx() (liblognorm.h) and pass it here. */
 struct ln_ctx_s;
 
-#if defined(ENABLE_TURBO) || defined(LOGNORM_TURBO_SUPPORTED)
-
+/* size_t / int64_t appear in the public signatures (the real prototypes and the
+ * no-op stubs alike), so the standard headers are needed no matter which branch
+ * compiles.  Standard headers only -- never config.h (see the note above). */
 #include <stddef.h>
 #include <stdint.h>
+
+#if defined(ENABLE_TURBO) || defined(LOGNORM_TURBO_SUPPORTED)
 
 #ifdef __cplusplus
 extern "C" {
@@ -217,7 +220,14 @@ void ln_fast_result_snapshot_free(ln_fast_result_snapshot_t *snap);
 
 /* No-op stubs mirroring the full public surface, so consumers can compile and
  * link unconditionally even when TurboVM is not built. Calls in conditional
- * (runtime-disabled but still compiled) blocks degrade to error/empty values. */
+ * (runtime-disabled but still compiled) blocks degrade to error/empty values.
+ *
+ * Implemented as static inline functions, NOT function-like macros: a macro
+ * that discards its arguments leaves the caller's locals unreferenced (tripping
+ * -Wunused-variable in consumer builds) and type-checks nothing.  The inline
+ * stubs use their parameters (cast to void) and mirror the real signatures, so
+ * consumer code compiles identically whether or not TurboVM is present. */
+
 typedef void *ln_fast_result_t;
 typedef void *ln_fast_result_snapshot_t;
 
@@ -232,21 +242,125 @@ typedef enum {
 
 #define LN_FFIELD_NESTED 0x04
 
-#define ln_turbo_is_available(ctx)                        (0)
-#define ln_turbo_normalize_to_str(ctx, str, len, js, jl)  (-1)
-#define ln_turbo_normalize_raw(ctx, str, len, r)          (-1)
-#define ln_fast_result_field_count(r)                     (0)
-#define ln_fast_result_get_field(r, idx, name, nlen, val, vlen)  (-1)
-#define ln_fast_result_get_field_typed(r, idx, name, nlen, type, flags, sval, slen, ival, dval)  (-1)
-#define ln_fast_result_get_string(r, name, val, vlen)     (-1)
-#define ln_fast_result_get_int(r, name, val)              (-1)
-#define ln_fast_result_tag_count(r)                       (0)
-#define ln_fast_result_get_tag(r, idx)                    ((const char *)0)
-#define ln_fast_result_has_tag(r, tag)                    (0)
-#define ln_fast_result_get_rule_id(r)                     ((const char *)0)
-#define ln_turbo_snapshot_result(ctx)                     ((void *)0)
-#define ln_fast_result_snapshot_get(snap)                 ((void *)0)
-#define ln_fast_result_snapshot_free(snap)                ((void)(snap))
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static inline int
+ln_turbo_is_available(struct ln_ctx_s *ctx)
+{
+	(void)ctx;
+	return 0;
+}
+
+static inline int
+ln_turbo_normalize_to_str(struct ln_ctx_s *ctx, const char *str, size_t strLen,
+		char **json_str, size_t *json_len)
+{
+	(void)ctx; (void)str; (void)strLen; (void)json_str; (void)json_len;
+	return -1;
+}
+
+static inline int
+ln_turbo_normalize_raw(struct ln_ctx_s *ctx, const char *str, size_t strLen,
+		const ln_fast_result_t **result)
+{
+	(void)ctx; (void)str; (void)strLen; (void)result;
+	return -1;
+}
+
+static inline int
+ln_fast_result_field_count(const ln_fast_result_t *r)
+{
+	(void)r;
+	return 0;
+}
+
+static inline int
+ln_fast_result_get_field(const ln_fast_result_t *r, int idx,
+		const char **name, size_t *nlen, const char **value, size_t *vlen)
+{
+	(void)r; (void)idx; (void)name; (void)nlen; (void)value; (void)vlen;
+	return -1;
+}
+
+static inline int
+ln_fast_result_get_field_typed(const ln_fast_result_t *r, int idx,
+		const char **name, size_t *nlen, ln_ftype_t *type, unsigned *flags,
+		const char **sval, size_t *slen, int64_t *ival, double *dval)
+{
+	(void)r; (void)idx; (void)name; (void)nlen; (void)type; (void)flags;
+	(void)sval; (void)slen; (void)ival; (void)dval;
+	return -1;
+}
+
+static inline int
+ln_fast_result_get_string(const ln_fast_result_t *r, const char *name,
+		const char **value, size_t *vlen)
+{
+	(void)r; (void)name; (void)value; (void)vlen;
+	return -1;
+}
+
+static inline int
+ln_fast_result_get_int(const ln_fast_result_t *r, const char *name,
+		int64_t *value)
+{
+	(void)r; (void)name; (void)value;
+	return -1;
+}
+
+static inline int
+ln_fast_result_tag_count(const ln_fast_result_t *r)
+{
+	(void)r;
+	return 0;
+}
+
+static inline const char *
+ln_fast_result_get_tag(const ln_fast_result_t *r, int idx)
+{
+	(void)r; (void)idx;
+	return (const char *)0;
+}
+
+static inline int
+ln_fast_result_has_tag(const ln_fast_result_t *r, const char *tag)
+{
+	(void)r; (void)tag;
+	return 0;
+}
+
+static inline const char *
+ln_fast_result_get_rule_id(const ln_fast_result_t *r)
+{
+	(void)r;
+	return (const char *)0;
+}
+
+static inline ln_fast_result_snapshot_t *
+ln_turbo_snapshot_result(struct ln_ctx_s *ctx)
+{
+	(void)ctx;
+	return (ln_fast_result_snapshot_t *)0;
+}
+
+static inline const ln_fast_result_t *
+ln_fast_result_snapshot_get(const ln_fast_result_snapshot_t *snap)
+{
+	(void)snap;
+	return (const ln_fast_result_t *)0;
+}
+
+static inline void
+ln_fast_result_snapshot_free(ln_fast_result_snapshot_t *snap)
+{
+	(void)snap;
+}
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ENABLE_TURBO || LOGNORM_TURBO_SUPPORTED */
 

--- a/src/lognorm-turbo.h
+++ b/src/lognorm-turbo.h
@@ -161,7 +161,7 @@ int ln_fast_result_get_field(const ln_fast_result_t *r, int idx,
  */
 int ln_fast_result_get_field_typed(const ln_fast_result_t *r, int idx,
 								   const char **name, size_t *nlen,
-								   unsigned *type, unsigned *flags,
+								   ln_ftype_t *type, unsigned *flags,
 								   const char **sval, size_t *slen,
 								   int64_t *ival, double *dval);
 

--- a/src/turbo.c
+++ b/src/turbo.c
@@ -653,12 +653,24 @@ compile_node(compiler_t *comp, struct ln_pdag *node, uint32_t *entry)
 
 	*entry = first;
 
+	/* A node can be terminal AND still have continuation parsers when its
+	 * rule is a strict prefix of a longer rule.  The continuations are tried
+	 * first; if they all fail the terminal OP_MATCH below must still be
+	 * reachable, so reserve a fallback fork to it here (lowest priority). */
+	uint32_t term_fallback_pc = UINT32_MAX;
+	if (node->flags.isTerminal) {
+		term_fallback_pc = emit_fork(comp);
+		if (term_fallback_pc == UINT32_MAX) { comp->depth--; return -1; }
+	}
+
 	if (node->nparsers == 1) {
 		uint32_t pc;
 		r = compile_parser(comp, &node->parsers[0], &pc);
 		if (r != 0) { comp->depth--; return r; }
 
 		if (node->flags.isTerminal) {
+			comp->turbo->code[term_fallback_pc].data.jump.offset =
+				(int32_t)comp->turbo->code_len - (int32_t)term_fallback_pc;
 			if (comp->in_custom_type == 0) {
 				if (emit_match(comp, node) == UINT32_MAX) {
 					comp->depth--;
@@ -707,6 +719,8 @@ compile_node(compiler_t *comp, struct ln_pdag *node, uint32_t *entry)
 	free(fork_pcs);
 
 	if (node->flags.isTerminal) {
+		comp->turbo->code[term_fallback_pc].data.jump.offset =
+			(int32_t)comp->turbo->code_len - (int32_t)term_fallback_pc;
 		if (comp->in_custom_type == 0) {
 			if (emit_match(comp, node) == UINT32_MAX) {
 				comp->depth--;

--- a/src/turbo.c
+++ b/src/turbo.c
@@ -430,12 +430,13 @@ struct data_NameValue {
 	bool ignore_whitespaces; /* trim surrounding whitespace for key/value */
 };
 
-/* Forward declaration for char-sep parser data (defined in parser.c).
- * Layout matches the beginning of data_CharTo — both start with
- * term_chars + n_term_chars, so the cast is ABI-safe. */
+/* Mirrors the layout-prefix of parser.c's private data_CharTo /
+ * data_CharSeparated (no shared header). Both start with the same two fields;
+ * types must match parser.c exactly -- n_term_chars is size_t, not int (an int
+ * mirror only happens to work on little-endian LP64). Keep in lockstep. */
 struct data_CharSeparated {
-	char *term_chars;
-	int   n_term_chars;
+	char  *term_chars;
+	size_t n_term_chars;
 };
 
 /* Forward declaration for Checkpoint LEA parser data (defined in parser.c). */
@@ -1060,7 +1061,7 @@ ln_fast_result_get_field(const ln_fast_result_t *r, int idx,
 int
 ln_fast_result_get_field_typed(const ln_fast_result_t *r, int idx,
 							   const char **name, size_t *nlen,
-							   unsigned *type, unsigned *flags,
+							   ln_ftype_t *type, unsigned *flags,
 							   const char **sval, size_t *slen,
 							   int64_t *ival, double *dval)
 {
@@ -1068,7 +1069,7 @@ ln_fast_result_get_field_typed(const ln_fast_result_t *r, int idx,
 	const ln_fast_field_t *f = &r->fields[idx];
 	if (name)  *name  = f->name;
 	if (nlen)  *nlen  = f->name_len;
-	if (type)  *type  = f->type;
+	if (type)  *type  = (ln_ftype_t)f->type;
 	if (flags) *flags = (unsigned)(f->flags & LN_FFIELD_NESTED);
 	switch (f->type) {
 	case LN_FTYPE_STRING:

--- a/src/turbo.c
+++ b/src/turbo.c
@@ -347,6 +347,19 @@ emit_annotation_fields(compiler_t *comp, struct ln_pdag *node)
 static uint32_t
 emit_match(compiler_t *comp, struct ln_pdag *node)
 {
+	/* A top-level rule matches only when it has consumed the ENTIRE input:
+	 * the recursive normalizer accepts a terminal for normalization only at
+	 * end-of-input.  Assert that first so turbo agrees — otherwise a rule
+	 * whose last parser stops before EOL, or a strict-prefix rule reached via
+	 * the fallback fork, would falsely match a longer line on its trailing
+	 * bytes.  (Custom-type sub-matches end in OP_RET, not here, so they are
+	 * unaffected.) */
+	ln_instr_t end_instr = {0};
+	end_instr.op = OP_ASSERT_END;
+	uint32_t entry = emit(comp, &end_instr);
+	if (entry == UINT32_MAX)
+		return UINT32_MAX;
+
 	/* Emit tags first — these populate result.tags[] */
 	if (emit_tags(comp, node) != 0)
 		return UINT32_MAX;
@@ -366,7 +379,11 @@ emit_match(compiler_t *comp, struct ln_pdag *node)
 	}
 
 	comp->n_rules++;
-	return emit(comp, &instr);
+	if (emit(comp, &instr) == UINT32_MAX)
+		return UINT32_MAX;
+	/* Entry is the ASSERT_END — every path into this terminal (sequential,
+	 * fallback fork, or a sibling-branch fork) goes through the EOL gate. */
+	return entry;
 }
 
 static uint32_t

--- a/src/turbo.c
+++ b/src/turbo.c
@@ -1022,6 +1022,43 @@ ln_fast_result_get_field(const ln_fast_result_t *r, int idx,
 }
 
 int
+ln_fast_result_get_field_typed(const ln_fast_result_t *r, int idx,
+							   const char **name, size_t *nlen,
+							   unsigned *type, unsigned *flags,
+							   const char **sval, size_t *slen,
+							   int64_t *ival, double *dval)
+{
+	if (!r || idx < 0 || idx >= r->n_fields) return -1;
+	const ln_fast_field_t *f = &r->fields[idx];
+	if (name)  *name  = f->name;
+	if (nlen)  *nlen  = f->name_len;
+	if (type)  *type  = f->type;
+	if (flags) *flags = (unsigned)(f->flags & LN_FFIELD_NESTED);
+	switch (f->type) {
+	case LN_FTYPE_STRING:
+		if (sval) *sval = f->v.str.ptr;
+		if (slen) *slen = f->v.str.len;
+		break;
+	case LN_FTYPE_STRING_INLINE:
+		if (sval) *sval = f->v.inl;
+		if (slen) *slen = strlen(f->v.inl);
+		break;
+	case LN_FTYPE_INT:
+		if (ival) *ival = f->v.i;
+		break;
+	case LN_FTYPE_BOOL:
+		if (ival) *ival = f->v.b ? 1 : 0;
+		break;
+	case LN_FTYPE_DOUBLE:
+		if (dval) *dval = f->v.d;
+		break;
+	default: /* LN_FTYPE_NULL */
+		break;
+	}
+	return 0;
+}
+
+int
 ln_fast_result_get_string(const ln_fast_result_t *r, const char *name,
 						  const char **value, size_t *vlen)
 {

--- a/src/turbo.c
+++ b/src/turbo.c
@@ -405,10 +405,12 @@ emit_ctx_pop(compiler_t *comp)
 
 static int compile_node(compiler_t *comp, struct ln_pdag *node, uint32_t *entry);
 
-/* Forward declaration for name-value-list parser data (defined in parser.c) */
+/* Forward declaration for name-value-list parser data (defined in parser.c).
+ * Layout must match struct data_NameValue in parser.c. */
 struct data_NameValue {
 	char sep;   /* separator (between key/value pairs) */
 	char ass;   /* assignator (between key and value) */
+	bool ignore_whitespaces; /* trim surrounding whitespace for key/value */
 };
 
 /* Forward declaration for char-sep parser data (defined in parser.c).
@@ -525,18 +527,21 @@ compile_parser(compiler_t *comp, ln_parser_t *prs, uint32_t *out_pc)
 		instr.op = OP_SKIP_SPACE;
 		pc = emit(comp, &instr);
 	} else if (op == OP_FIELD_NAME_VALUE) {
-		/* name-value-list: extract sep/ass from parser_data */
+		/* name-value-list: extract sep/ass/ignore_whitespaces from parser_data */
 		char sep = 0, ass = 0;  /* 0 = default (whitespace sep, '=' ass) */
+		uint8_t ignore_ws = 0;
 		if (prs->parser_data) {
 			struct data_NameValue *nvdata = (struct data_NameValue *)prs->parser_data;
 			sep = nvdata->sep;
 			ass = nvdata->ass;
+			ignore_ws = nvdata->ignore_whitespaces ? 1 : 0;
 		}
 		ln_instr_t instr = {0};
 		instr.op = OP_FIELD_NAME_VALUE;
 		instr.flags = LN_INSTR_F_STORE;
 		instr.data.char_to.delim = (uint8_t)sep;
 		instr.data.char_to.ass   = (uint8_t)ass;
+		instr.data.char_to.ignore_ws = ignore_ws;
 		if (prs->name) {
 			size_t nlen = strlen(prs->name);
 			if (nlen >= sizeof(instr.data.char_to.name))

--- a/src/turbo.c
+++ b/src/turbo.c
@@ -801,6 +801,7 @@ ln_turbo_ctx_free(ln_turbo_ctx_t *turbo)
 		free(turbo->json_buf);
 		turbo->json_buf = NULL;
 	}
+	ln_vm_destroy(&turbo->vm);
 	if (turbo->arena.base) {
 		ln_arena_destroy(&turbo->arena);
 	}

--- a/src/turbo.h
+++ b/src/turbo.h
@@ -1,6 +1,10 @@
 /**
  * @file turbo.h
- * @brief liblognorm integration for TurboVM bytecode engine
+ * @brief liblognorm integration for TurboVM bytecode engine (internal).
+ *
+ * INTERNAL header — not installed. The public, opaque Turbo API lives in
+ * lognorm-turbo.h (which this header includes); only internal lifecycle,
+ * legacy and debug entry points are declared here.
  *//*
  * Copyright 2024-2026 by Advens and Jeremie Jourdin.
  * Copyright 2015-2026 by Rainer Gerhards and Adiscon GmbH.
@@ -17,6 +21,9 @@
 #include "config.h"
 #endif
 
+/* Public, opaque Turbo API (opaque types, enum, accessors, snapshots). */
+#include "lognorm-turbo.h"
+
 #if defined(ENABLE_TURBO) || defined(LOGNORM_TURBO_SUPPORTED)
 
 #include <stddef.h>
@@ -27,24 +34,17 @@
 extern "C" {
 #endif
 
-/* Forward declarations */
-typedef struct ln_ctx_s *ln_ctx;
+/* Forward declarations (ln_ctx comes from lognorm-turbo.h) */
 struct json_object;  /* libfastjson (for legacy API only) */
 
 /*============================================================================
- * Turbo VM State (opaque)
+ * Turbo VM State (opaque, internal)
  *============================================================================*/
 
 typedef struct ln_turbo_ctx_s ln_turbo_ctx_t;
 
 /*============================================================================
- * Fast Result Structure (opaque for external use)
- *============================================================================*/
-
-typedef struct ln_fast_result_s ln_fast_result_t;
-
-/*============================================================================
- * Context Management
+ * Context Management (internal lifecycle)
  *============================================================================*/
 
 /**
@@ -68,44 +68,9 @@ void ln_turbo_ctx_free(ln_turbo_ctx_t *turbo);
  */
 int ln_turbo_compile(ln_ctx ctx);
 
-/**
- * Check if turbo VM is available for this context.
- */
-int ln_turbo_is_available(ln_ctx ctx);
-
 /*============================================================================
- * Normalization API - Choose based on your needs
+ * Legacy normalization (libfastjson object output) — internal
  *============================================================================*/
-
-/**
- * Normalize using turbo VM - JSON string output.
- * Best for CLI tools and JSON pipelines.
- *
- * @param ctx       liblognorm context
- * @param str       Input string to normalize
- * @param strLen    Length of input string
- * @param json_str  Receives JSON string (caller must free)
- * @param json_len  Receives JSON string length
- * @return 0 on match, negative on no match/error
- */
-int ln_turbo_normalize_to_str(ln_ctx ctx, const char *str, size_t strLen,
-							  char **json_str, size_t *json_len);
-
-/**
- * Normalize using turbo VM - direct result access.
- * Best for rsyslog - ZERO JSON overhead!
- *
- * Result is valid until next normalize call on same context.
- * DO NOT free the result - it's owned by the turbo context.
- *
- * @param ctx       liblognorm context
- * @param str       Input string to normalize
- * @param strLen    Length of input string
- * @param result    Receives pointer to internal result structure
- * @return 0 on match, negative on no match/error
- */
-int ln_turbo_normalize_raw(ln_ctx ctx, const char *str, size_t strLen,
-						   const ln_fast_result_t **result);
 
 /**
  * Normalize using turbo VM - libfastjson object output.
@@ -121,110 +86,7 @@ int ln_turbo_normalize(ln_ctx ctx, const char *str, size_t strLen,
 					   struct json_object **json_p);
 
 /*============================================================================
- * Direct Field Access API (for rsyslog - no JSON overhead)
- *============================================================================*/
-
-/**
- * Get number of fields in result.
- */
-int ln_fast_result_field_count(const ln_fast_result_t *r);
-
-/**
- * Get field by index.
- *
- * @param r      Result
- * @param idx    Field index (0 to field_count-1)
- * @param name   Receives field name pointer (do not free)
- * @param nlen   Receives name length
- * @param value  Receives value pointer (do not free)
- * @param vlen   Receives value length
- * @return 0 on success, -1 if index out of range
- */
-int ln_fast_result_get_field(const ln_fast_result_t *r, int idx,
-							 const char **name, size_t *nlen,
-							 const char **value, size_t *vlen);
-
-/**
- * Get string field by name.
- *
- * @param r      Result
- * @param name   Field name to find
- * @param value  Receives value pointer
- * @param vlen   Receives value length
- * @return 0 if found, -1 if not found
- */
-int ln_fast_result_get_string(const ln_fast_result_t *r, const char *name,
-							  const char **value, size_t *vlen);
-
-/**
- * Get integer field by name.
- *
- * @param r      Result
- * @param name   Field name to find
- * @param value  Receives integer value
- * @return 0 if found, -1 if not found or not an integer
- */
-int ln_fast_result_get_int(const ln_fast_result_t *r, const char *name,
-						   int64_t *value);
-
-/**
- * Get number of tags in result.
- */
-int ln_fast_result_tag_count(const ln_fast_result_t *r);
-
-/**
- * Get tag by index.
- *
- * @param r    Result
- * @param idx  Tag index (0 to tag_count-1)
- * @return Tag string or NULL if index out of range
- */
-const char *ln_fast_result_get_tag(const ln_fast_result_t *r, int idx);
-
-/**
- * Check if result has a specific tag.
- *
- * @param r    Result
- * @param tag  Tag to check
- * @return 1 if tag present, 0 if not
- */
-int ln_fast_result_has_tag(const ln_fast_result_t *r, const char *tag);
-
-/**
- * Get matched rule ID.
- *
- * @param r  Result
- * @return Rule ID string or NULL if no match
- */
-const char *ln_fast_result_get_rule_id(const ln_fast_result_t *r);
-
-/*============================================================================
- * Snapshot API (for rsyslog zero-JSON hot path)
- *============================================================================*/
-
-/**
- * Forward declare snapshot type.
- * Full definition in turbo_snapshot.h.
- */
-typedef struct ln_fast_result_snapshot_s ln_fast_result_snapshot_t;
-
-/**
- * Create a snapshot of the current turbo parse result.
- *
- * Must be called after a successful ln_turbo_normalize_raw() and before
- * the next normalize call on the same context (which resets the arena).
- *
- * The snapshot is a self-contained deep copy: single allocation containing
- * the result struct + arena data, with all pointers rebased.
- *
- * @param ctx  liblognorm context with a valid turbo result
- * @return Snapshot (caller must free with ln_fast_result_snapshot_free),
- *         or NULL on failure
- */
-ln_fast_result_snapshot_t *ln_turbo_snapshot_result(ln_ctx ctx);
-
-/*============================================================================
- * Statistics
+ * Statistics & debug (internal)
  *============================================================================*/
 
 typedef struct {
@@ -259,21 +121,14 @@ void ln_turbo_disasm(ln_ctx ctx, FILE *fp, const char *label);
 
 #else /* !ENABLE_TURBO && !LOGNORM_TURBO_SUPPORTED */
 
-/* Stub definitions when turbo is disabled */
+/* Stub definitions when turbo is disabled (public data-type stubs and the
+ * public entry-point stubs are provided by lognorm-turbo.h). */
 typedef void *ln_turbo_ctx_t;
-typedef void *ln_fast_result_t;
-typedef void *ln_fast_result_snapshot_t;
 
 #define ln_turbo_ctx_init()          NULL
 #define ln_turbo_ctx_free(t)         ((void)(t))
 #define ln_turbo_compile(ctx)        (-1)
-#define ln_turbo_is_available(ctx)   (0)
 #define ln_turbo_normalize(ctx, str, len, json) (-1)
-#define ln_turbo_normalize_to_str(ctx, str, len, js, jl) (-1)
-#define ln_turbo_normalize_raw(ctx, str, len, r) (-1)
-#define ln_turbo_snapshot_result(ctx)             ((void*)0)
-#define ln_fast_result_snapshot_get(snap)         ((void*)0)
-#define ln_fast_result_snapshot_free(snap)        ((void)(snap))
 #define ln_turbo_disasm(ctx, fp, label)          ((void)0)
 
 #endif /* ENABLE_TURBO || LOGNORM_TURBO_SUPPORTED */

--- a/src/turbo_arena.c
+++ b/src/turbo_arena.c
@@ -212,6 +212,19 @@ ln_arena_alloc(ln_arena_t *arena, size_t size)
 }
 
 void *
+ln_arena_alloc_array(ln_arena_t *arena, size_t nmemb, size_t elem)
+{
+	/* Checked multiply: reject nmemb * elem that would wrap (CWE-190).
+	 * ln_arena_alloc() sees only the (already-wrapped) product and cannot
+	 * detect the overflow itself, so the guard must live here. */
+	if (elem != 0 && nmemb > SIZE_MAX / elem) {
+		return NULL;
+	}
+
+	return ln_arena_alloc(arena, nmemb * elem);
+}
+
+void *
 ln_arena_alloc_aligned(ln_arena_t *arena, size_t size, size_t alignment)
 {
 	size_t current;

--- a/src/turbo_arena.h
+++ b/src/turbo_arena.h
@@ -218,6 +218,25 @@ void ln_arena_destroy(ln_arena_t *arena);
 void *ln_arena_alloc(ln_arena_t *arena, size_t size);
 
 /**
+ * @brief Allocate an array of `nmemb` elements of `elem` bytes from the arena.
+ *
+ * Computes the total allocation size as `nmemb * elem` with a checked
+ * multiply. If the product would overflow size_t (CWE-190), returns NULL
+ * instead of allocating an undersized region. This is the safe primitive
+ * behind the LN_ARENA_ARRAY() macro and must be used whenever the element
+ * count may be derived from untrusted input.
+ *
+ * @param[in] arena  Arena to allocate from (must not be NULL)
+ * @param[in] nmemb  Number of elements
+ * @param[in] elem   Size of each element in bytes
+ * @return Pointer to allocated memory, or NULL on overflow or exhaustion
+ *
+ * @note Returned pointer is valid until arena is reset or destroyed.
+ * @note The memory is NOT initialized.
+ */
+void *ln_arena_alloc_array(ln_arena_t *arena, size_t nmemb, size_t elem);
+
+/**
  * @brief Allocate aligned memory from the arena.
  *
  * Returns a pointer to at least `size` bytes of memory, aligned to
@@ -442,7 +461,7 @@ void ln_arena_get_stats(const ln_arena_t *arena, ln_arena_stats_t *stats);
  * @endcode
  */
 #define LN_ARENA_ARRAY(arena, type, count) \
-	((type *)ln_arena_alloc((arena), sizeof(type) * (count)))
+	((type *)ln_arena_alloc_array((arena), (count), sizeof(type)))
 
 /**
  * @brief Allocate an aligned typed object from the arena.

--- a/src/turbo_json_impl.c
+++ b/src/turbo_json_impl.c
@@ -437,16 +437,19 @@ ln_fast_json_estimate(const ln_fast_result_t *r)
 		if (!f->name) continue;
 
 		/* Each dot in name generates an extra object: "key":{ ... }
-		 * Worst case: each component needs "name":{  = name_len + 4
-		 * Plus closing braces. Generous estimate: name_len * 2 + 8 */
-		est += f->name_len * 2 + 8;
+		 * Worst-case JSON escaping expands ONE byte to six ("\uXXXX"),
+		 * and each dot expands to a nested-object wrapper. Budget
+		 * name_len * 6 (full \uXXXX expansion) + 8 structural slack
+		 * (quotes, colon, brace) so the buffer is always large enough. */
+		est += f->name_len * 6 + 8;
 
 		switch (f->type) {
 		case LN_FTYPE_STRING:
-			est += f->v.str.len * 2 + 2;  /* Worst case escaping */
+			/* Worst case: every byte -> "\uXXXX" (6) + 2 quotes */
+			est += f->v.str.len * 6 + 2;
 			break;
 		case LN_FTYPE_STRING_INLINE:
-			est += LN_FAST_INLINE_SIZE * 2 + 2;
+			est += LN_FAST_INLINE_SIZE * 6 + 2;
 			break;
 		case LN_FTYPE_INT:
 			est += 21;
@@ -465,7 +468,9 @@ ln_fast_json_estimate(const ln_fast_result_t *r)
 		est += 20;  /* "event":{"tags":[ or "tags":[ + closing */
 		for (uint8_t i = 0; i < r->n_tags; i++) {
 			if (r->tags[i].tag)
-				est += strlen(r->tags[i].tag) + 3;
+				/* Tags also go through write_escaped_string:
+				 * every byte may expand to "\uXXXX" (6) + quotes/comma. */
+				est += strlen(r->tags[i].tag) * 6 + 3;
 		}
 	}
 

--- a/src/turbo_opcode.h
+++ b/src/turbo_opcode.h
@@ -181,7 +181,9 @@ static inline ln_instr_t ln_i_match(const char *rule) {
 	ln_instr_t i = {0};
 	i.op = OP_MATCH;
 	if (rule) {
-		for (int j = 0; j < LN_INSTR_MAX_INLINE && rule[j]; j++)
+		/* Reserve a NUL terminator: copy at most size-1 bytes so the
+		 * inline string is always NUL-terminated (security audit #6). */
+		for (int j = 0; j < LN_INSTR_MAX_INLINE - 1 && rule[j]; j++)
 			i.data.str[j] = rule[j];
 	}
 	return i;
@@ -191,6 +193,11 @@ static inline ln_instr_t ln_i_match(const char *rule) {
 static inline ln_instr_t ln_i_literal(const char *lit, uint16_t len) {
 	ln_instr_t i = {0};
 	i.op = OP_LITERAL;
+	/* Clamp the inline copy to the buffer; aux carries the match length
+	 * the VM compares, so it must never exceed what we actually stored
+	 * inline (security audit #6 — VM also re-validates len <= inline size). */
+	if (len > LN_INSTR_MAX_INLINE)
+		len = LN_INSTR_MAX_INLINE;
 	i.aux = len;
 	for (uint16_t j = 0; j < len && j < LN_INSTR_MAX_INLINE; j++)
 		i.data.str[j] = lit[j];
@@ -234,7 +241,8 @@ static inline ln_instr_t ln_i_field(ln_opcode_t op, const char *name) {
 	i.op = op;
 	i.flags = LN_INSTR_F_STORE;
 	if (name) {
-		for (int j = 0; j < LN_INSTR_MAX_INLINE && name[j]; j++)
+		/* Reserve a NUL terminator (security audit #6). */
+		for (int j = 0; j < LN_INSTR_MAX_INLINE - 1 && name[j]; j++)
 			i.data.str[j] = name[j];
 	}
 	return i;
@@ -247,7 +255,8 @@ static inline ln_instr_t ln_i_field_char_to(const char *name, char delim) {
 	i.flags = LN_INSTR_F_STORE;
 	i.data.char_to.delim = (uint8_t)delim;
 	if (name) {
-		for (int j = 0; j < 56 && name[j]; j++)
+		/* Reserve a NUL terminator (security audit #6). name[56]. */
+		for (int j = 0; j < 56 - 1 && name[j]; j++)
 			i.data.char_to.name[j] = name[j];
 	}
 	return i;
@@ -263,7 +272,8 @@ static inline ln_instr_t ln_i_field_name_value(const char *name, char sep, char 
 	i.data.char_to.ass   = (uint8_t)ass;
 	i.data.char_to.ignore_ws = ignore_ws;
 	if (name) {
-		for (int j = 0; j < 56 && name[j]; j++)
+		/* Reserve a NUL terminator (security audit #6). name[56]. */
+		for (int j = 0; j < 56 - 1 && name[j]; j++)
 			i.data.char_to.name[j] = name[j];
 	}
 	return i;
@@ -289,7 +299,8 @@ static inline ln_instr_t ln_i_tag(const char *tag) {
 	ln_instr_t i = {0};
 	i.op = OP_TAG;
 	if (tag) {
-		for (int j = 0; j < LN_INSTR_MAX_INLINE && tag[j]; j++)
+		/* Reserve a NUL terminator (security audit #6). */
+		for (int j = 0; j < LN_INSTR_MAX_INLINE - 1 && tag[j]; j++)
 			i.data.str[j] = tag[j];
 	}
 	return i;
@@ -300,7 +311,8 @@ static inline ln_instr_t ln_i_ctx_push(const char *name) {
 	ln_instr_t i = {0};
 	i.op = OP_CTX_PUSH;
 	if (name) {
-		for (int j = 0; j < LN_INSTR_MAX_INLINE && name[j]; j++)
+		/* Reserve a NUL terminator (security audit #6). */
+		for (int j = 0; j < LN_INSTR_MAX_INLINE - 1 && name[j]; j++)
 			i.data.str[j] = name[j];
 	}
 	return i;

--- a/src/turbo_opcode.h
+++ b/src/turbo_opcode.h
@@ -141,7 +141,8 @@ typedef struct {
 			char     name[56]; /**< Field name */
 			uint8_t  delim;    /**< Delimiter char */
 			uint8_t  ass;      /**< Assignator char (for name-value-list) */
-			uint8_t  _pad[2];
+			uint8_t  ignore_ws;/**< name-value-list: trim surrounding whitespace */
+			uint8_t  _pad[1];
 		} char_to;
 
 		/* Static key-value pair (for OP_STATIC_FIELD) */
@@ -253,12 +254,14 @@ static inline ln_instr_t ln_i_field_char_to(const char *name, char delim) {
 }
 
 /** Create FIELD_NAME_VALUE instruction */
-static inline ln_instr_t ln_i_field_name_value(const char *name, char sep, char ass) {
+static inline ln_instr_t ln_i_field_name_value(const char *name, char sep, char ass,
+											   uint8_t ignore_ws) {
 	ln_instr_t i = {0};
 	i.op = OP_FIELD_NAME_VALUE;
 	i.flags = LN_INSTR_F_STORE;
 	i.data.char_to.delim = (uint8_t)sep;
 	i.data.char_to.ass   = (uint8_t)ass;
+	i.data.char_to.ignore_ws = ignore_ws;
 	if (name) {
 		for (int j = 0; j < 56 && name[j]; j++)
 			i.data.char_to.name[j] = name[j];

--- a/src/turbo_result_fast.h
+++ b/src/turbo_result_fast.h
@@ -15,6 +15,11 @@
 #include <stddef.h>
 #include <string.h>
 
+/* Public, opaque API: the ln_fast_result_t typedef, the ln_ftype_t field-type
+ * enum and the LN_FFIELD_NESTED flag are defined there. This header completes
+ * the (otherwise opaque) struct and adds the internal-only builders. */
+#include "lognorm-turbo.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -34,19 +39,6 @@ extern "C" {
 
 /** Tag hash table size (power of 2) */
 #define LN_FAST_TAG_HASH_SIZE 32
-
-/*============================================================================
- * Field Types
- *============================================================================*/
-
-typedef enum {
-	LN_FTYPE_NULL = 0,
-	LN_FTYPE_STRING,       /* External string (ptr + len) */
-	LN_FTYPE_STRING_INLINE,/* Inline string (no alloc) */
-	LN_FTYPE_INT,
-	LN_FTYPE_DOUBLE,
-	LN_FTYPE_BOOL,
-} ln_ftype_t;
 
 /*============================================================================
  * Field Structure (64 bytes - cache line aligned)
@@ -73,10 +65,9 @@ typedef struct {
 
 _Static_assert(sizeof(ln_fast_field_t) == 64, "Field must be 64 bytes");
 
-/* Field flags */
+/* Field flags (LN_FFIELD_NESTED 0x04 is public, see lognorm-turbo.h) */
 #define LN_FFIELD_STATIC_NAME 0x01  /* Name is static (don't free) */
 #define LN_FFIELD_STATIC_VAL  0x02  /* Value is static (don't free) */
-#define LN_FFIELD_NESTED      0x04  /* Part of nested object (name has dots) */
 
 /**
  * @brief Check if a field name contains a dot (indicating nested object).
@@ -104,7 +95,8 @@ typedef struct {
  * Fast Result Structure
  *============================================================================*/
 
-typedef struct ln_fast_result_s {
+/* Completes the opaque ln_fast_result_t declared in lognorm-turbo.h. */
+struct ln_fast_result_s {
 	/* Fields array */
 	ln_fast_field_t fields[LN_FAST_MAX_FIELDS];
 	uint8_t         n_fields;
@@ -124,7 +116,7 @@ typedef struct ln_fast_result_s {
 	
 	/* Arena for any overflow allocations */
 	void           *arena;
-} ln_fast_result_t;
+};
 
 /* Result flags */
 #define LN_FRESULT_MATCHED   0x01

--- a/src/turbo_simd.c
+++ b/src/turbo_simd.c
@@ -71,13 +71,34 @@ build_char_class(const char *chars, uint8_t table[256])
 
 #if defined(LN_SIMD_SSE42)
 
-/* @brief  Optimized SSE4.2 char set loader */
+/*
+ * @brief  Optimized SSE4.2 char set loader.
+ *
+ * Loads up to 16 characters of the set into an XMM register and, via
+ * @p set_len, reports the true number of set characters loaded (clamped
+ * to the 16-byte SSE operand width). The reported length is what feeds
+ * PCMPESTRI's explicit set-operand length so embedded NULs inside the
+ * data chunk no longer truncate the comparison (the implicit-length
+ * PCMPISTRI bug). A set with a NUL byte is itself terminated at that
+ * NUL here, matching the strchr()/lookup-table tail which also treats
+ * @p chars as a C string.
+ *
+ * Note: PCMPESTRI's set operand is 16 bytes wide, so we lift the former
+ * 15-char strncpy truncation to a full 16-char cap.
+ */
 static inline __m128i
-ln_simd_load_chars(const char *chars)
+ln_simd_load_chars(const char *chars, int *set_len)
 {
 	uint8_t padded[16] = {0};
+	size_t n = 0;
 	if (chars) {
-		strncpy((char*)padded, chars, 15);
+		while (n < 16 && chars[n] != '\0') {
+			padded[n] = (uint8_t)chars[n];
+			n++;
+		}
+	}
+	if (set_len) {
+		*set_len = (int)n;
 	}
 	return _mm_loadu_si128((const __m128i *)(const void *)padded);
 }
@@ -127,16 +148,24 @@ size_t
 ln_simd_find_char_set(const char *buf, size_t len, const char *chars)
 {
 	__m128i set;
+	int set_len;
 	size_t i;
 
 	if (!buf || len == 0 || !chars || !*chars) return len;
 
-	set = ln_simd_load_chars(chars);
+	set = ln_simd_load_chars(chars, &set_len);
 	i = 0;
 
 	while (i + 16 <= len) {
 		 __m128i chunk = _mm_loadu_si128((const __m128i *)(const void *)(buf + i));
-		 int index = _mm_cmpistri(set, chunk, _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY);
+		 /*
+		  * Explicit-length PCMPESTRI: honour the true data length (16 here,
+		  * a full chunk) and set length so an embedded NUL inside the chunk
+		  * no longer terminates the comparison early. Implicit-length
+		  * PCMPISTRI would have ignored every byte past the first NUL.
+		  */
+		 int index = _mm_cmpestri(set, set_len, chunk, 16,
+			 _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY);
 		 if (index < 16) return i + index;
 		 i += 16;
 	}
@@ -153,18 +182,22 @@ ln_simd_find_char_set(const char *buf, size_t len, const char *chars)
 size_t
 ln_simd_find_not_char_set(const char *buf, size_t len, const char *chars)
 {
-	uint8_t padded_set[16] = {0};
 	__m128i set;
+	int set_len;
 	size_t i;
 
 	if (!buf || len == 0 || !chars) return 0;
-	strncpy((char*)padded_set, chars, 15);
-	set = _mm_loadu_si128((const __m128i *)(const void *)padded_set);
+	set = ln_simd_load_chars(chars, &set_len);
 	i = 0;
 	while (i + 16 <= len) {
 		__m128i chunk = _mm_loadu_si128((const __m128i *)(const void *)(buf + i));
-		/* Negative Polarity finds the first char that is NOT in the 'chars' set */
-		int index = _mm_cmpistri(set, chunk,
+		/*
+		 * Negative Polarity finds the first char that is NOT in the 'chars'
+		 * set. Explicit-length PCMPESTRI honours the full 16-byte data
+		 * length so an embedded NUL in the chunk is treated as a normal
+		 * (not-in-set) byte rather than terminating the scan early.
+		 */
+		int index = _mm_cmpestri(set, set_len, chunk, 16,
 			_SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY | _SIDD_NEGATIVE_POLARITY);
 		if (index < 16) return i + index;
 		i += 16;
@@ -184,13 +217,22 @@ ln_simd_skip_space(const char *buf, size_t len)
 
 	if (!buf || len == 0) return 0;
 
-	/* Ranges: 0x09-0x0D (TAB, LF, VT, FF, CR) and 0x20 (SPACE) */
+	/*
+	 * Ranges: 0x09-0x0D (TAB, LF, VT, FF, CR) and 0x20 (SPACE).
+	 * Two ranges = 4 boundary bytes, so the explicit set length is 4.
+	 */
 	ranges = _mm_setr_epi8(0x09, 0x0D, 0x20, 0x20, 0,0,0,0,0,0,0,0,0,0,0,0);
 	i = 0;
 	while (i + 16 <= len) {
 		__m128i chunk = _mm_loadu_si128((const __m128i *)(const void *)(buf + i));
-		/* Find first character NOT in the whitespace range */
-		int index = _mm_cmpistri(ranges, chunk, _SIDD_UBYTE_OPS | _SIDD_CMP_RANGES | _SIDD_NEGATIVE_POLARITY);
+		/*
+		 * Find first character NOT in the whitespace range. Explicit-length
+		 * PCMPESTRI honours the full 16-byte data length: a NUL byte (0x00)
+		 * is outside the whitespace ranges, so it correctly terminates the
+		 * skip rather than being ignored by implicit-length scanning.
+		 */
+		int index = _mm_cmpestri(ranges, 4, chunk, 16,
+			_SIDD_UBYTE_OPS | _SIDD_CMP_RANGES | _SIDD_NEGATIVE_POLARITY);
 		if (index < 16) return i + index;
 		i += 16;
 	}

--- a/src/turbo_snapshot.c
+++ b/src/turbo_snapshot.c
@@ -56,13 +56,50 @@ rebase_ptr(const char *ptr, const uint8_t *old_base, const char *new_base)
 	return new_base + offset;
 }
 
+/**
+ * @brief Number of trailing bytes a non-arena string needs in the snapshot
+ *        backing buffer when it has to be copied in (len + 1 for the NUL).
+ *
+ * A pointer needs copying iff it is non-NULL and does NOT already live in the
+ * arena region (those are handled by the cheap rebase path). The byte count
+ * uses the stored length — values carry an explicit length and may contain
+ * embedded NULs; names are length-prefixed too. We always append a trailing
+ * NUL so the snapshot strings stay C-string compatible like the originals.
+ */
+static inline size_t
+copy_bytes_if_external(const char *ptr, size_t len,
+					   const uint8_t *arena_base, size_t arena_used)
+{
+	if (!ptr) return 0;
+	if (arena_base && ptr_in_arena(ptr, arena_base, arena_used)) return 0;
+	return len + 1;
+}
+
+/**
+ * @brief Append @p len bytes from @p src into the snapshot backing buffer at
+ *        @p *off, NUL-terminate, and return the destination pointer. Advances
+ *        @p *off past the written bytes (+ the NUL).
+ */
+static inline const char *
+append_external(char *backing, size_t *off, const char *src, size_t len)
+{
+	char *dst = backing + *off;
+	memcpy(dst, src, len);
+	dst[len] = '\0';
+	*off += len + 1;
+	return dst;
+}
+
 ln_fast_result_snapshot_t *
 ln_fast_result_snapshot_create(const ln_fast_result_t *src,
 								const ln_arena_t *arena)
 {
 	size_t arena_used = 0;
 	const uint8_t *arena_base = NULL;
+	size_t extra = 0;        /* bytes for non-arena strings copied in */
+	size_t off;              /* bump offset into the backing buffer    */
 	size_t total;
+	char *backing;
 	ln_fast_result_snapshot_t *snap;
 
 	if (!src) return NULL;
@@ -73,62 +110,97 @@ ln_fast_result_snapshot_create(const ln_fast_result_t *src,
 		arena_base = arena->base;
 	}
 
-	/* Single allocation: header + arena data */
-	total = sizeof(ln_fast_result_snapshot_t) + arena_used;
+	/* Pass 1: size the extra space needed for every pointer that does NOT
+	 * live in the arena and therefore cannot be rebased. "Not in arena" does
+	 * NOT imply "long-lived/static" — OP_FIELD_REST/WORD/STR_TO/CHAR_TO/QUOTED
+	 * store long (>= LN_FAST_INLINE_SIZE) values as raw pointers straight into
+	 * the input line. Those, plus non-static names and the original message,
+	 * must be copied so the snapshot can outlive the input line. */
+	for (int i = 0; i < src->n_fields; i++) {
+		const ln_fast_field_t *f = &src->fields[i];
+
+		if (f->type == LN_FTYPE_STRING)
+			extra += copy_bytes_if_external(f->v.str.ptr, f->v.str.len,
+											arena_base, arena_used);
+		if (!(f->flags & LN_FFIELD_STATIC_NAME))
+			extra += copy_bytes_if_external(f->name, f->name_len,
+											arena_base, arena_used);
+	}
+	extra += copy_bytes_if_external(src->original, src->original_len,
+									arena_base, arena_used);
+
+	/* Single allocation: header + arena data + non-arena string copies */
+	total = sizeof(ln_fast_result_snapshot_t) + arena_used + extra;
 	snap = malloc(total);
 	if (!snap) return NULL;
 
 	/* Copy the result struct */
 	memcpy(&snap->result, src, sizeof(ln_fast_result_t));
-	snap->arena_size = arena_used;
+	/* arena_size tracks the whole owned backing region (arena + extra) so the
+	 * snapshot remains a single self-contained allocation. */
+	snap->arena_size = arena_used + extra;
 
-	/* Copy arena bytes */
+	backing = snap->arena_data;
+
+	/* Copy arena bytes into the head of the backing buffer */
 	if (arena_used > 0) {
-		memcpy(snap->arena_data, arena_base, arena_used);
+		memcpy(backing, arena_base, arena_used);
 	}
 
 	/* Detach from original arena — snapshot is self-contained */
 	snap->result.arena = NULL;
 
-	/* Rebase all pointers that reference the arena region */
+	/* Pass 2: rebase arena pointers; copy-and-repoint non-arena ones. The
+	 * non-arena copies are bump-appended after the arena region. */
+	off = arena_used;
 	for (int i = 0; i < snap->result.n_fields; i++) {
 		ln_fast_field_t *f = &snap->result.fields[i];
 
-		/* Rebase field name if it points into the arena */
-		if (f->name && arena_base &&
-			!(f->flags & LN_FFIELD_STATIC_NAME) &&
-			ptr_in_arena(f->name, arena_base, arena_used)) {
-			f->name = rebase_ptr(f->name, arena_base,
-								 (const char *)snap->arena_data);
+		/* Field name: rebase if in arena, else copy in (unless static). */
+		if (f->name && !(f->flags & LN_FFIELD_STATIC_NAME)) {
+			if (arena_base && ptr_in_arena(f->name, arena_base, arena_used)) {
+				f->name = rebase_ptr(f->name, arena_base, backing);
+			} else {
+				f->name = append_external(backing, &off,
+										  f->name, f->name_len);
+			}
 		}
 
-		/* Rebase string value if it points into the arena */
-		if (f->type == LN_FTYPE_STRING && f->v.str.ptr &&
-			arena_base &&
-			ptr_in_arena(f->v.str.ptr, arena_base, arena_used)) {
-			f->v.str.ptr = rebase_ptr(f->v.str.ptr, arena_base,
-									  (const char *)snap->arena_data);
+		/* String value: rebase if in arena, else copy in. */
+		if (f->type == LN_FTYPE_STRING && f->v.str.ptr) {
+			if (arena_base &&
+				ptr_in_arena(f->v.str.ptr, arena_base, arena_used)) {
+				f->v.str.ptr = rebase_ptr(f->v.str.ptr, arena_base, backing);
+			} else {
+				f->v.str.ptr = append_external(backing, &off,
+											   f->v.str.ptr, f->v.str.len);
+			}
 		}
 		/* LN_FTYPE_STRING_INLINE: data is inline in the struct, already copied */
 		/* LN_FTYPE_INT/DOUBLE/BOOL: no pointers to rebase */
 	}
 
-	/* Rebase rule_id if it points into the arena (unlikely, usually static) */
+	/* Rebase rule_id if it points into the arena (otherwise it is a
+	 * compile-time-static rule identifier with program lifetime). */
 	if (snap->result.rule_id && arena_base &&
 		ptr_in_arena(snap->result.rule_id, arena_base, arena_used)) {
 		snap->result.rule_id = rebase_ptr(snap->result.rule_id, arena_base,
-										  (const char *)snap->arena_data);
+										  backing);
 	}
 
-	/* Note: original message pointer (result.original) typically points
-	 * into the input buffer, NOT the arena. We leave it as-is because
-	 * the input buffer outlives the snapshot in the rsyslog pipeline
-	 * (message string is on the smsg_t). If it pointed into the arena,
-	 * we'd rebase it too. */
-	if (snap->result.original && arena_base &&
-		ptr_in_arena(snap->result.original, arena_base, arena_used)) {
-		snap->result.original = rebase_ptr(snap->result.original, arena_base,
-										   (const char *)snap->arena_data);
+	/* Original message: rebase if in arena, else copy in. It usually points
+	 * straight into the (caller-owned, soon-to-be-freed/reused) input line,
+	 * so a verbatim pointer copy would dangle. */
+	if (snap->result.original) {
+		if (arena_base &&
+			ptr_in_arena(snap->result.original, arena_base, arena_used)) {
+			snap->result.original = rebase_ptr(snap->result.original,
+											   arena_base, backing);
+		} else {
+			snap->result.original = append_external(backing, &off,
+													snap->result.original,
+													snap->result.original_len);
+		}
 	}
 
 	/* Tag strings are static (compile-time constants), no rebasing needed */

--- a/src/turbo_snapshot.h
+++ b/src/turbo_snapshot.h
@@ -14,6 +14,9 @@
 #include "config.h"
 #endif
 
+/* Public opaque snapshot type + get/free decls (and disabled-build stubs). */
+#include "lognorm-turbo.h"
+
 #if defined(ENABLE_TURBO) || defined(LOGNORM_TURBO_SUPPORTED)
 
 #include <stddef.h>
@@ -30,11 +33,12 @@ extern "C" {
  * Memory layout: header struct followed by inline arena data copy.
  * All arena pointers in the result are rebased to point into arena_data[].
  */
-typedef struct ln_fast_result_snapshot_s {
+/* Completes the opaque ln_fast_result_snapshot_t declared in lognorm-turbo.h. */
+struct ln_fast_result_snapshot_s {
 	ln_fast_result_t result;    /**< Deep copy of result (pointers rebased) */
 	size_t           arena_size;/**< Size of arena data copy */
 	char             arena_data[];/**< Flexible array: arena bytes follow inline */
-} ln_fast_result_snapshot_t;
+};
 
 /**
  * @brief Create a snapshot from a turbo parse result.
@@ -53,27 +57,8 @@ ln_fast_result_snapshot_t *
 ln_fast_result_snapshot_create(const ln_fast_result_t *src,
 								const ln_arena_t *arena);
 
-/**
- * @brief Get the result from a snapshot.
- *
- * The returned pointer is valid for the lifetime of the snapshot.
- * It can be used with all ln_fast_result_* accessor functions.
- *
- * @param snap  Snapshot to read from
- * @return Pointer to the result, or NULL if snap is NULL
- */
-const ln_fast_result_t *
-ln_fast_result_snapshot_get(const ln_fast_result_snapshot_t *snap);
-
-/**
- * @brief Free a snapshot.
- *
- * Single free() — the snapshot is a single allocation.
- *
- * @param snap  Snapshot to free (NULL-safe)
- */
-void
-ln_fast_result_snapshot_free(ln_fast_result_snapshot_t *snap);
+/* ln_fast_result_snapshot_get() and ln_fast_result_snapshot_free() are part
+ * of the public, opaque API and are declared in lognorm-turbo.h. */
 
 #ifdef __cplusplus
 }
@@ -81,11 +66,9 @@ ln_fast_result_snapshot_free(ln_fast_result_snapshot_t *snap);
 
 #else /* !ENABLE_TURBO && !LOGNORM_TURBO_SUPPORTED */
 
-/* Stubs when turbo is disabled */
-typedef void ln_fast_result_snapshot_t;
+/* Stubs when turbo is disabled (the snapshot type and the public get/free
+ * stubs are provided by lognorm-turbo.h, included via turbo_result_fast.h). */
 #define ln_fast_result_snapshot_create(src, arena)  ((void*)0)
-#define ln_fast_result_snapshot_get(snap)           ((void*)0)
-#define ln_fast_result_snapshot_free(snap)          ((void)(snap))
 
 #endif /* ENABLE_TURBO || LOGNORM_TURBO_SUPPORTED */
 

--- a/src/turbo_vm.c
+++ b/src/turbo_vm.c
@@ -1138,6 +1138,7 @@ vm_exec_instr(ln_vm_t *vm)
 		const char sep = (char)inst->data.char_to.delim;  /* 0 = whitespace */
 		const char ass = (char)inst->data.char_to.ass;     /* 0 = '=' */
 		const char ass_char = ass ? ass : '=';
+		const int ignore_ws = inst->data.char_to.ignore_ws;
 		const char *p;
 		const char *end;
 		int n_pairs;
@@ -1154,12 +1155,20 @@ vm_exec_instr(ln_vm_t *vm)
 
 		while (p < end) {
 			/* --- Parse name --- */
-			const char *name_start = p;
-			size_t name_end_off;
-			size_t name_len;
+			const char *name_start;
+			size_t name_end_off; /* raw distance to assignator */
+			size_t name_len;     /* stored name length (may be trimmed) */
 			const char *val_start;
 			size_t val_len;
 			char *arena_name;
+
+			/* ignore_whitespaces: skip leading whitespace before the name
+			 * (SIMD-accelerated; same whitespace class as isspace). */
+			if (ignore_ws) {
+				p += ln_simd_skip_space(p, (size_t)(end - p));
+				if (p >= end) break;
+			}
+			name_start = p;
 
 			/* Scan for assignator char using SIMD find_char */
 			name_end_off = ln_simd_find_char(p, (size_t)(end - p), ass_char);
@@ -1172,23 +1181,36 @@ vm_exec_instr(ln_vm_t *vm)
 			name_len = name_end_off;
 			if (name_len == 0) break;
 
-			/* Validate name characters: alnum, '.', '_', '-' */
 			if (ass == 0) {
-				/* Default mode: strict name validation */
+				/* Default mode: name must be a contiguous run of valid
+				 * chars immediately followed by '=' (matches the
+				 * standard parser; no trailing-whitespace trim here). */
 				int valid = 1;
 				size_t k;
 				for (k = 0; k < name_len; k++) {
-					unsigned char c = (unsigned char)p[k];
+					unsigned char c = (unsigned char)name_start[k];
 					if (!(isalnum(c) || c == '.' || c == '_' || c == '-')) {
 						valid = 0;
 						break;
 					}
 				}
 				if (!valid) break;
+			} else if (ignore_ws) {
+				/* Custom assignator: name is anything before ass; trim its
+				 * trailing whitespace to match the standard parser. */
+				while (name_len > 0
+					&& isspace((unsigned char)name_start[name_len - 1]))
+					name_len--;
+				if (name_len == 0) break;
 			}
-			/* else: custom assignator mode — name is anything before ass */
 
-			p += name_len + 1; /* skip name + assignator */
+			p += name_end_off + 1; /* skip name span + assignator */
+
+			/* ignore_whitespaces: skip whitespace between assignator and
+			 * value (SIMD-accelerated). */
+			if (ignore_ws) {
+				p += ln_simd_skip_space(p, (size_t)(end - p));
+			}
 
 			/* --- Parse value --- */
 			if (p < end && (*p == '"' || *p == '\'')) {
@@ -1225,6 +1247,13 @@ vm_exec_instr(ln_vm_t *vm)
 						val_len++;
 				}
 				p += val_len;
+				/* ignore_whitespaces: trim trailing whitespace from an
+				 * unquoted value (quoted values are kept verbatim). */
+				if (ignore_ws) {
+					while (val_len > 0
+						&& isspace((unsigned char)val_start[val_len - 1]))
+						val_len--;
+				}
 			}
 
 			/* --- Store the field --- */
@@ -1237,7 +1266,17 @@ vm_exec_instr(ln_vm_t *vm)
 			vm_add_string_field(vm, arena_name, val_start, val_len);
 			n_pairs++;
 
-			/* --- Skip separator(s) --- */
+			/* --- Advance to the next pair ---
+			 * Matches the standard parser: with ignore_whitespaces and a
+			 * custom separator, skip whitespace before the separator; then
+			 * a separator (whitespace when sep == 0) must follow, otherwise
+			 * stop. Finally consume the separator run. */
+			if (ignore_ws && sep) {
+				p += ln_simd_skip_space(p, (size_t)(end - p));
+			}
+			if (p < end
+				&& !(sep ? (*p == sep) : isspace((unsigned char)*p)))
+				break;
 			if (sep) {
 				while (p < end && *p == sep) p++;
 			} else {
@@ -2329,6 +2368,7 @@ ln_vm_continue(ln_vm_t *vm)
 		char sep;
 		char ass;
 		char ass_char;
+		int ignore_ws;
 		int n_pairs;
 
 		vm->instr_count++;
@@ -2339,6 +2379,7 @@ ln_vm_continue(ln_vm_t *vm)
 		sep = (char)inst->data.char_to.delim;
 		ass = (char)inst->data.char_to.ass;
 		ass_char = ass ? ass : '=';
+		ignore_ws = inst->data.char_to.ignore_ws;
 
 		if (ctx_name[0]) {
 			vm_push_field_ctx(vm, ctx_name, false);
@@ -2349,12 +2390,20 @@ ln_vm_continue(ln_vm_t *vm)
 		n_pairs = 0;
 
 		while (p < end) {
-			const char *name_start = p;
-			size_t name_end_off;
-			size_t name_len;
+			const char *name_start;
+			size_t name_end_off; /* raw distance to assignator */
+			size_t name_len;     /* stored name length (may be trimmed) */
 			const char *val_start;
 			size_t val_len;
 			char *arena_name;
+
+			/* ignore_whitespaces: skip leading whitespace before the name
+			 * (SIMD-accelerated; same whitespace class as isspace). */
+			if (ignore_ws) {
+				p += ln_simd_skip_space(p, (size_t)(end - p));
+				if (p >= end) break;
+			}
+			name_start = p;
 
 			name_end_off = ln_simd_find_char(p, (size_t)(end - p), ass_char);
 			if (name_end_off >= (size_t)(end - p)) break;
@@ -2363,19 +2412,33 @@ ln_vm_continue(ln_vm_t *vm)
 			if (name_len == 0) break;
 
 			if (ass == 0) {
+				/* Default mode: contiguous valid-char name followed by '='
+				 * (matches the standard parser; no trailing-ws trim). */
 				int valid = 1;
 				size_t k;
 				for (k = 0; k < name_len; k++) {
-					unsigned char c = (unsigned char)p[k];
+					unsigned char c = (unsigned char)name_start[k];
 					if (!(isalnum(c) || c == '.' || c == '_' || c == '-')) {
 						valid = 0;
 						break;
 					}
 				}
 				if (!valid) break;
+			} else if (ignore_ws) {
+				/* Custom assignator: trim the name's trailing whitespace. */
+				while (name_len > 0
+					&& isspace((unsigned char)name_start[name_len - 1]))
+					name_len--;
+				if (name_len == 0) break;
 			}
 
-			p += name_len + 1;
+			p += name_end_off + 1; /* skip name span + assignator */
+
+			/* ignore_whitespaces: skip whitespace between assignator and
+			 * value (SIMD-accelerated). */
+			if (ignore_ws) {
+				p += ln_simd_skip_space(p, (size_t)(end - p));
+			}
 
 			if (p < end && (*p == '"' || *p == '\'')) {
 				char quote = *p;
@@ -2405,6 +2468,12 @@ ln_vm_continue(ln_vm_t *vm)
 						val_len++;
 				}
 				p += val_len;
+				/* ignore_whitespaces: trim trailing ws from unquoted value */
+				if (ignore_ws) {
+					while (val_len > 0
+						&& isspace((unsigned char)val_start[val_len - 1]))
+						val_len--;
+				}
 			}
 
 			/* Arena-allocate name so it outlives this stack frame */
@@ -2415,6 +2484,13 @@ ln_vm_continue(ln_vm_t *vm)
 			vm_add_string_field(vm, arena_name, val_start, val_len);
 			n_pairs++;
 
+			/* Advance to the next pair (see scalar handler for rationale). */
+			if (ignore_ws && sep) {
+				p += ln_simd_skip_space(p, (size_t)(end - p));
+			}
+			if (p < end
+				&& !(sep ? (*p == sep) : isspace((unsigned char)*p)))
+				break;
 			if (sep) {
 				while (p < end && *p == sep) p++;
 			} else {

--- a/src/turbo_vm.c
+++ b/src/turbo_vm.c
@@ -248,7 +248,27 @@ ln_vm_init(ln_vm_t *vm, ln_arena_t *arena)
 	memset(vm, 0, sizeof(*vm));
 	vm->arena = arena;
 
+	/* Private C locale for locale-independent number parsing (strtod_l). JSON
+	 * numbers always use '.' as the decimal point, but plain strtod() honours
+	 * LC_NUMERIC and would read "1.5" as 1.0 under a comma-decimal locale. "C"
+	 * needs no locale files, so newlocale only fails on OOM; on failure we fail
+	 * init, so the caller drops turbo and uses the locale-independent v1 path
+	 * rather than ever parsing a number under the wrong locale. Freed by
+	 * ln_vm_destroy. */
+	vm->c_locale = (void *)newlocale(LC_NUMERIC_MASK, "C", (locale_t)0);
+	if (vm->c_locale == NULL) return LN_VM_ERROR;
+
 	return LN_VM_OK;
+}
+
+void
+ln_vm_destroy(ln_vm_t *vm)
+{
+	if (!vm) return;
+	if (vm->c_locale != NULL) {
+		freelocale((locale_t)vm->c_locale);
+		vm->c_locale = NULL;
+	}
 }
 
 void
@@ -1010,45 +1030,22 @@ json_emit_double(ln_json_ctx_t *c, double v)
 		c->n_emitted++;
 }
 
-/* JSON numbers always use '.' as the decimal separator, but strtod() honours the
- * process LC_NUMERIC, so in a comma-decimal locale (de_DE, fr_FR, ...) it would
- * parse "1.5" as 1.0 -- silently corrupting the value and diverging from the v1
- * path (libfastjson, which is locale-independent). We parse through a private C
- * locale (strtod_l) instead. The locale is an immutable process-global resource:
- * created once at library load, before any thread starts, and never modified, so
- * sharing it across threads needs no locking. */
-static locale_t turbo_c_locale;
-
-__attribute__((constructor))
-static void turbo_c_locale_init(void)
-{
-	turbo_c_locale = newlocale(LC_NUMERIC_MASK, "C", (locale_t)0);
-}
-
-__attribute__((destructor))
-static void turbo_c_locale_fini(void)
-{
-	if (turbo_c_locale != (locale_t)0) {
-		freelocale(turbo_c_locale);
-		turbo_c_locale = (locale_t)0;
-	}
-}
-
 /*
  * Emit s[0..len) (an already grammar-validated JSON number span) as a double.
  * The common case fits the stack buffer; a pathologically long number is copied
  * in full via the VM arena, because truncating to the stack buffer could cut a
  * trailing 'eNN' exponent and silently corrupt the magnitude. Parsing goes
- * through the private C locale (strtod_l) so the decimal point is always '.'
- * regardless of the process locale; out-of-range values saturate to +/-HUGE_VAL
- * per C, which is acceptable here.
+ * through the VM's private C locale (strtod_l), so the decimal point is always
+ * '.' regardless of the process LC_NUMERIC -- matching the locale-independent v1
+ * path; out-of-range values saturate to +/-HUGE_VAL per C, acceptable here. The
+ * locale is guaranteed valid here: ln_vm_init fails if it cannot be created, so
+ * the turbo context is never built and the v1 path is used instead.
  */
 static void
 json_emit_double_span(ln_json_ctx_t *c, const char *s, size_t len)
 {
 	char stackbuf[64];
 	const char *num;
-	double v;
 
 	if (len < sizeof(stackbuf)) {
 		memcpy(stackbuf, s, len);
@@ -1058,11 +1055,7 @@ json_emit_double_span(ln_json_ctx_t *c, const char *s, size_t len)
 		num = ln_arena_strndup(c->vm->arena, s, len);
 		if (num == NULL) return;   /* OOM: drop this field, keep the line */
 	}
-	/* Plain strtod only as a fallback if newlocale() failed at load (OOM). */
-	v = (turbo_c_locale != (locale_t)0)
-		? strtod_l(num, NULL, turbo_c_locale)
-		: strtod(num, NULL);
-	json_emit_double(c, v);
+	json_emit_double(c, strtod_l(num, NULL, (locale_t)c->vm->c_locale));
 }
 
 /* bool emitted as the STRING "true"/"false" (string-store convention). */

--- a/src/turbo_vm.c
+++ b/src/turbo_vm.c
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <ctype.h>
 
 /*============================================================================
@@ -772,6 +773,456 @@ parse_json(const char *buf, size_t len, size_t *out_len)
 	return -1;
 }
 
+/*============================================================================
+ * SIMD-accelerated JSON flattening
+ *============================================================================
+ *
+ * OP_FIELD_JSON flattens a nested JSON object into the flat result store using
+ * dotted keys (e.g. {"alert":{"severity":3}} -> "alert.severity"=3). The
+ * dotted keys integrate with the existing flat result-tree key convention --
+ * the JSON serializer re-nests them on output -- and reuse the same separator
+ * the other nested turbo fields use (vm_build_field_name '.').
+ *
+ * Design: a length-gated hybrid scan that REUSES the VM's existing SIMD
+ * primitives (ln_simd_find_char / ln_simd_skip_space -- SSE4.2 + NEON + scalar
+ * backends) rather than inventing new vector machinery, so OP_FIELD_JSON
+ * inherits the dual-arch + scalar fallback contract for free.
+ *
+ *   - Structural walk (scalar recursive descent): typical log JSON is
+ *     structurally DENSE -- structural bytes sit only a few bytes apart -- so a
+ *     16-wide vector structural-set scan loses its per-chunk setup cost against
+ *     a tight scalar dispatch on the next byte. A pure-SIMD structural-set scan
+ *     measured slower than the scalar walk on representative log corpora, so we
+ *     walk structural bytes scalarly.
+ *   - String-body leap (length-gated SIMD): the one place long byte runs occur
+ *     is inside long string values (URLs, long identifiers). json_scan_string()
+ *     uses ln_simd_find_char() to jump to the closing quote, but ONLY when the
+ *     remaining span is >= 2 vector widths; short bodies take the scalar path.
+ *     This yields the SIMD win where it exists and zero regression where it
+ *     doesn't.
+ *   - Whitespace is skipped via the vectorized ln_simd_skip_space().
+ *
+ * Value lifetime (correctness landmine): BOTH the dotted key and any string
+ * value are ln_arena_strndup'd into the VM arena before we return. The flat
+ * store keeps STATIC (non-owning) pointers; only arena pointers survive for the
+ * lifetime of the result. A pointer into the transient input line would dangle.
+ * Keys are built in a small stack buffer then arena-duped.
+ */
+
+#define LN_JSON_MAX_DEPTH  64           /* matches LN_FAST_MAX_FIELDS ceiling */
+#define LN_JSON_KEYBUF     512          /* dotted-path scratch (stack) */
+
+typedef struct {
+	ln_vm_t      *vm;
+	const char   *buf;          /* whole JSON span being parsed */
+	size_t        len;
+	size_t        pos;          /* scalar cursor (offset into buf) */
+	char          key[LN_JSON_KEYBUF];  /* current dotted prefix */
+	size_t        key_len;      /* bytes used in key[] */
+	int           n_emitted;    /* leaves added to the flat store */
+	bool          full;         /* hit LN_FAST_MAX_FIELDS -- stop adding */
+} ln_json_ctx_t;
+
+/*
+ * Stage-1 SIMD skip of insignificant whitespace at ctx->pos. Reuses the VM's
+ * vectorized whitespace skip.
+ */
+static inline void
+json_skip_ws(ln_json_ctx_t *c)
+{
+	if (c->pos < c->len)
+		c->pos += ln_simd_skip_space(c->buf + c->pos, c->len - c->pos);
+}
+
+/*
+ * Stage-1 SIMD scan of a JSON string body starting just AFTER the opening
+ * quote. Uses ln_simd_find_char() to leap to the next '"' and corrects for
+ * backslash escapes scalarly (escapes are rare in typical log JSON, so the SIMD
+ * leap dominates). On return str/slen describe the raw (still-escaped) body
+ * and ctx->pos points just past the closing quote. Returns -1 if unterminated.
+ */
+static int
+json_scan_string(ln_json_ctx_t *c, const char **str, size_t *slen)
+{
+	size_t start = c->pos;          /* first byte of body */
+	size_t p = c->pos;
+
+	for (;;) {
+		size_t rem = c->len - p;
+		size_t off;
+		size_t bs = 0;
+		size_t q;
+		/* Length-gated SIMD: typical log JSON is structurally dense (short
+		 * string bodies, structural bytes a few bytes apart) so a 16-wide
+		 * vector scan loses its per-chunk setup cost against a tight scalar
+		 * loop on short bodies. We only pay for SIMD once a long body
+		 * (>= 2 vector widths) is plausible -- that captures the long values
+		 * (URLs, long identifiers) where the leap actually pays off. Net:
+		 * scalar-or-better on dense JSON, SIMD win on long values, zero
+		 * regression elsewhere. */
+		if (rem >= 2 * LN_SIMD_WIDTH) {
+			off = ln_simd_find_char(c->buf + p, rem, '"');
+		} else {
+			off = 0;
+			while (off < rem && c->buf[p + off] != '"') off++;
+		}
+		if (off >= rem) return -1;  /* no closing quote */
+		p += off;
+		/* count preceding backslashes to know if this quote is escaped */
+		q = p;
+		while (q > start && c->buf[q - 1] == '\\') { bs++; q--; }
+		if ((bs & 1) == 0) {        /* even => real closing quote */
+			*str = c->buf + start;
+			*slen = p - start;
+			c->pos = p + 1;         /* consume closing quote */
+			return 0;
+		}
+		p++;                        /* escaped quote, keep scanning */
+		if (p >= c->len) return -1;
+	}
+}
+
+/*
+ * Unescape a raw JSON string body into an arena buffer (the common JSON
+ * sequences: \" \\ \/ \n \r \t \b \f and \uXXXX -> UTF-8).
+ * If the body has no backslash, we arena-strndup directly (fast path). Returns
+ * arena pointer + out length, or NULL on OOM.
+ */
+static const char *
+json_unescape_arena(ln_vm_t *vm, const char *s, size_t n, size_t *out_len)
+{
+	const char *bs = memchr(s, '\\', n);
+	char *dst;
+	size_t o = 0;
+	size_t i;
+	if (bs == NULL) {
+		char *dup = ln_arena_strndup(vm->arena, s, n);
+		if (dup) *out_len = n;
+		return dup;
+	}
+	dst = ln_arena_alloc(vm->arena, n + 1);
+	if (!dst) return NULL;
+	for (i = 0; i < n; i++) {
+		char ch = s[i];
+		if (ch == '\\' && i + 1 < n) {
+			char e = s[++i];
+			switch (e) {
+			case '"':  dst[o++] = '"';  break;
+			case '\\': dst[o++] = '\\'; break;
+			case '/':  dst[o++] = '/';  break;
+			case 'n':  dst[o++] = '\n'; break;
+			case 'r':  dst[o++] = '\r'; break;
+			case 't':  dst[o++] = '\t'; break;
+			case 'b':  dst[o++] = '\b'; break;
+			case 'f':  dst[o++] = '\f'; break;
+			case 'u': {
+				/* \uXXXX -> UTF-8 (BMP only; surrogate pairs left as-is). */
+				if (i + 4 < n) {
+					unsigned cp = 0; int ok = 1, k;
+					for (k = 1; k <= 4; k++) {
+						char h = s[i + k]; unsigned d;
+						if (h >= '0' && h <= '9') d = (unsigned)(h - '0');
+						else if (h >= 'a' && h <= 'f') d = (unsigned)(h - 'a' + 10);
+						else if (h >= 'A' && h <= 'F') d = (unsigned)(h - 'A' + 10);
+						else { ok = 0; break; }
+						cp = (cp << 4) | d;
+					}
+					if (ok) {
+						i += 4;
+						if (cp < 0x80) {
+							dst[o++] = (char)cp;
+						} else if (cp < 0x800) {
+							dst[o++] = (char)(0xC0 | (cp >> 6));
+							dst[o++] = (char)(0x80 | (cp & 0x3F));
+						} else {
+							dst[o++] = (char)(0xE0 | (cp >> 12));
+							dst[o++] = (char)(0x80 | ((cp >> 6) & 0x3F));
+							dst[o++] = (char)(0x80 | (cp & 0x3F));
+						}
+						break;
+					}
+				}
+				dst[o++] = 'u';   /* malformed \u: emit literally */
+				break;
+			}
+			default: dst[o++] = e; break;
+			}
+		} else {
+			dst[o++] = ch;
+		}
+	}
+	dst[o] = '\0';
+	*out_len = o;
+	return dst;
+}
+
+/* Emit a leaf into the flat store. key[]/key_len is the dotted path. */
+static void
+json_emit_string(ln_json_ctx_t *c, const char *raw, size_t raw_len)
+{
+	size_t vlen;
+	const char *key;
+	const char *val;
+	if (c->full || c->vm->result == NULL) return;
+	if (c->vm->result->n_fields >= LN_FAST_MAX_FIELDS) { c->full = true; return; }
+	key = ln_arena_strndup(c->vm->arena, c->key, c->key_len);
+	val = json_unescape_arena(c->vm, raw, raw_len, &vlen);
+	if (!key || !val) return;
+	if (ln_fast_add_string_static(c->vm->result, key, (uint16_t)c->key_len,
+				      val, (uint32_t)vlen) == 0)
+		c->n_emitted++;
+}
+
+static void
+json_emit_int(ln_json_ctx_t *c, int64_t v)
+{
+	const char *key;
+	if (c->full || c->vm->result == NULL) return;
+	if (c->vm->result->n_fields >= LN_FAST_MAX_FIELDS) { c->full = true; return; }
+	key = ln_arena_strndup(c->vm->arena, c->key, c->key_len);
+	if (!key) return;
+	if (ln_fast_add_int_static(c->vm->result, key, (uint16_t)c->key_len, v) == 0)
+		c->n_emitted++;
+}
+
+static void
+json_emit_double(ln_json_ctx_t *c, double v)
+{
+	const char *key;
+	if (c->full || c->vm->result == NULL) return;
+	if (c->vm->result->n_fields >= LN_FAST_MAX_FIELDS) { c->full = true; return; }
+	key = ln_arena_strndup(c->vm->arena, c->key, c->key_len);
+	if (!key) return;
+	if (ln_fast_add_double_static(c->vm->result, key, (uint16_t)c->key_len, v) == 0)
+		c->n_emitted++;
+}
+
+/* bool emitted as the STRING "true"/"false" (string-store convention). */
+static void
+json_emit_bool(ln_json_ctx_t *c, bool v)
+{
+	json_emit_string(c, v ? "true" : "false", v ? 4 : 5);
+}
+
+static int json_parse_value(ln_json_ctx_t *c, int depth);
+
+/*
+ * Parse a JSON number at ctx->pos. Decides int vs double by presence of
+ * '.', 'e' or 'E'. Emits via json_emit_int / json_emit_double.
+ */
+static int
+json_parse_number(ln_json_ctx_t *c)
+{
+	const char *s = c->buf + c->pos;
+	size_t rem = c->len - c->pos;
+	size_t i = 0;
+	bool is_double = false;
+
+	if (i < rem && (s[i] == '-' || s[i] == '+')) i++;
+	while (i < rem) {
+		char ch = s[i];
+		if (ch >= '0' && ch <= '9') { i++; continue; }
+		if (ch == '.' || ch == 'e' || ch == 'E' || ch == '+' || ch == '-') {
+			is_double = true; i++; continue;
+		}
+		break;
+	}
+	if (i == 0) return -1;
+
+	if (is_double) {
+		char tmp[64];
+		size_t cl = i < sizeof(tmp) - 1 ? i : sizeof(tmp) - 1;
+		memcpy(tmp, s, cl); tmp[cl] = '\0';
+		json_emit_double(c, strtod(tmp, NULL));
+	} else {
+		int64_t v;
+		size_t consumed;
+		if (parse_number(s, i, &v, &consumed) == 0)
+			json_emit_int(c, v);
+		else {
+			/* overflow / too-long int: keep as double for fidelity */
+			char tmp[64];
+			size_t cl = i < sizeof(tmp) - 1 ? i : sizeof(tmp) - 1;
+			memcpy(tmp, s, cl); tmp[cl] = '\0';
+			json_emit_double(c, strtod(tmp, NULL));
+		}
+	}
+	c->pos += i;
+	return 0;
+}
+
+/*
+ * Parse a JSON object body: ctx->pos is just past '{'. Appends ".<key>" to the
+ * dotted path for each member, recurses into the value, then truncates back.
+ */
+static int
+json_parse_object(ln_json_ctx_t *c, int depth)
+{
+	size_t saved_len = c->key_len;
+
+	json_skip_ws(c);
+	if (c->pos < c->len && c->buf[c->pos] == '}') { c->pos++; return 0; }
+
+	for (;;) {
+		const char *kstr; size_t klen;
+
+		json_skip_ws(c);
+		if (c->pos >= c->len || c->buf[c->pos] != '"') return -1;
+		c->pos++;                                   /* opening quote */
+		if (json_scan_string(c, &kstr, &klen) != 0) return -1;
+
+		/* append ".<key>" to dotted path (truncate silently if it overflows) */
+		c->key_len = saved_len;
+		if (saved_len + 1 + klen < LN_JSON_KEYBUF) {
+			if (saved_len > 0) c->key[c->key_len++] = '.';
+			memcpy(c->key + c->key_len, kstr, klen);
+			c->key_len += klen;
+		}
+
+		json_skip_ws(c);
+		if (c->pos >= c->len || c->buf[c->pos] != ':') return -1;
+		c->pos++;                                   /* ':' */
+
+		if (json_parse_value(c, depth + 1) != 0) return -1;
+
+		c->key_len = saved_len;                     /* pop member key */
+
+		json_skip_ws(c);
+		if (c->pos >= c->len) return -1;
+		if (c->buf[c->pos] == ',') { c->pos++; continue; }
+		if (c->buf[c->pos] == '}') { c->pos++; return 0; }
+		return -1;
+	}
+}
+
+/*
+ * Parse a JSON array. Arrays are uncommon in flat log JSON, so we keep this
+ * minimal: scalar elements get an index-suffix key.N; object/array elements are
+ * structurally skipped (consumed but not flattened). This keeps the span
+ * consumption correct for v1 parity without object-array flattening.
+ */
+static int
+json_parse_array(ln_json_ctx_t *c, int depth)
+{
+	size_t saved_len = c->key_len;
+	int idx = 0;
+
+	json_skip_ws(c);
+	if (c->pos < c->len && c->buf[c->pos] == ']') { c->pos++; return 0; }
+
+	for (;;) {
+		char ib[24];
+		int n;
+
+		json_skip_ws(c);
+		if (c->pos >= c->len) return -1;
+
+		/* index-suffix key for scalar elements */
+		c->key_len = saved_len;
+		n = snprintf(ib, sizeof(ib), ".%d", idx);
+		if (n > 0 && saved_len + (size_t)n < LN_JSON_KEYBUF) {
+			memcpy(c->key + c->key_len, ib, (size_t)n);
+			c->key_len += (size_t)n;
+		}
+
+		if (json_parse_value(c, depth + 1) != 0) return -1;
+		c->key_len = saved_len;
+
+		json_skip_ws(c);
+		if (c->pos >= c->len) return -1;
+		if (c->buf[c->pos] == ',') { c->pos++; idx++; continue; }
+		if (c->buf[c->pos] == ']') { c->pos++; return 0; }
+		return -1;
+	}
+}
+
+static int
+json_parse_value(ln_json_ctx_t *c, int depth)
+{
+	if (depth > LN_JSON_MAX_DEPTH) return -1;
+	json_skip_ws(c);
+	if (c->pos >= c->len) return -1;
+
+	switch (c->buf[c->pos]) {
+	case '{':
+		c->pos++;
+		return json_parse_object(c, depth);
+	case '[':
+		c->pos++;
+		return json_parse_array(c, depth);
+	case '"': {
+		const char *s; size_t sl;
+		c->pos++;
+		if (json_scan_string(c, &s, &sl) != 0) return -1;
+		json_emit_string(c, s, sl);
+		return 0;
+	}
+	case 't':
+		if (c->len - c->pos >= 4 && memcmp(c->buf + c->pos, "true", 4) == 0) {
+			json_emit_bool(c, true); c->pos += 4; return 0;
+		}
+		return -1;
+	case 'f':
+		if (c->len - c->pos >= 5 && memcmp(c->buf + c->pos, "false", 5) == 0) {
+			json_emit_bool(c, false); c->pos += 5; return 0;
+		}
+		return -1;
+	case 'n':
+		if (c->len - c->pos >= 4 && memcmp(c->buf + c->pos, "null", 4) == 0) {
+			c->pos += 4; return 0;        /* null -> skip (no field) */
+		}
+		return -1;
+	default:
+		return json_parse_number(c);     /* number or invalid */
+	}
+}
+
+/*
+ * Top-level JSON flatten entry. Parses one JSON value (object or array) at buf,
+ * flattens leaves under field_name into vm->result, and reports the consumed
+ * byte span. Returns 0 on success (valid JSON), -1 on parse error.
+ *
+ * The flat keys are "<field_name>.<dotted.path>" so the serializer re-nests
+ * them under field_name -- matching the v1 parser's nested output.
+ */
+static int
+vm_json_flatten(ln_vm_t *vm, const char *field_name,
+		const char *buf, size_t len, size_t *out_consumed)
+{
+	ln_json_ctx_t c;
+	uint16_t fn_len;
+	const char *full_name;
+
+	if (len == 0) return -1;
+
+	/* peek first significant byte: must be object or array */
+	{
+		size_t lead = ln_simd_skip_space(buf, len);
+		if (lead >= len) return -1;
+		if (buf[lead] != '{' && buf[lead] != '[') return -1;
+	}
+
+	memset(&c, 0, sizeof(c));
+	c.vm  = vm;
+	c.buf = buf;
+	c.len = len;
+	c.pos = 0;
+
+	/* Seed the dotted prefix with the (context-resolved) field name so the
+	 * flattened leaves nest under it, exactly like vm_add_string_field. */
+	full_name = vm_build_field_name(vm, field_name, &fn_len);
+	if (full_name && full_name[0] && fn_len < LN_JSON_KEYBUF) {
+		memcpy(c.key, full_name, fn_len);
+		c.key_len = fn_len;
+	}
+
+	if (json_parse_value(&c, 0) != 0) return -1;
+
+	/* trailing insignificant whitespace inside the consumed span is fine */
+	*out_consumed = c.pos;
+	return 0;
+}
+
 static inline int
 parse_mac48(const char *buf, size_t len, size_t *out_len)
 {
@@ -1100,9 +1551,10 @@ vm_exec_instr(ln_vm_t *vm)
 		const char *name = inst->data.str;
 		size_t len;
 
-		if (parse_json(vm->ip, remaining, &len) != 0) return -1;
+		/* SIMD-flatten nested JSON into dotted flat keys. */
+		if (vm_json_flatten(vm, name, vm->ip, remaining, &len) != 0)
+			return -1;
 
-		vm_add_string_field(vm, name, vm->ip, len);
 		vm->ip += len;
 		vm->pc++;
 		return 1;
@@ -2307,12 +2759,15 @@ ln_vm_continue(ln_vm_t *vm)
 		const ln_instr_t *inst = INST();
 		size_t len;
 		vm->instr_count++;
-		if (UNLIKELY(parse_json(ip, REMAINING(), &len) != 0)) {
+		vm->ip = ip;
+		/* SIMD stage-1 structural scan + scalar stage-2 flatten.
+		 * On parse failure BACKTRACK restores result->n_fields from the
+		 * fork snapshot, rolling back any partially-emitted leaves. */
+		if (UNLIKELY(vm_json_flatten(vm, inst->data.str, ip,
+					     REMAINING(), &len) != 0)) {
 			WRITEBACK();
 			BACKTRACK();
 		}
-		vm->ip = ip;
-		vm_add_string_field(vm, inst->data.str, ip, len);
 		ip += len;
 		pc++;
 		DISPATCH();
@@ -3031,20 +3486,20 @@ ln_vm_continue(ln_vm_t *vm)
 			BACKTRACK();
 		}
 
-		/* Parse JSON body */
-		if (UNLIKELY(parse_json(p, rem, &json_len) != 0)) {
+		/* SIMD-flatten the CEE JSON body into dotted flat keys. */
+		vm->ip = ip;
+		if (UNLIKELY(vm_json_flatten(vm, fname, p, rem, &json_len) != 0)) {
 			WRITEBACK();
 			BACKTRACK();
 		}
 
-		/* JSON must consume rest of input */
+		/* JSON must consume rest of input (trailing whitespace allowed). */
+		json_len += ln_simd_skip_space(p + json_len, rem - json_len);
 		if (UNLIKELY(json_len != rem)) {
 			WRITEBACK();
 			BACKTRACK();
 		}
 
-		vm->ip = ip;
-		vm_add_string_field(vm, fname, p, json_len);
 		ip = p + json_len;
 		pc++;
 		DISPATCH();

--- a/src/turbo_vm.c
+++ b/src/turbo_vm.c
@@ -930,6 +930,10 @@ json_unescape_arena(ln_vm_t *vm, const char *s, size_t n, size_t *out_len)
 		if (dup) *out_len = n;
 		return dup;
 	}
+	/* n is an input-derived length; guard n+1 against size_t wrap -- n ==
+	 * SIZE_MAX would make ln_arena_alloc see 0 and round it up to a 1-byte
+	 * buffer, which the unescape loop below would then overflow. */
+	if (n == SIZE_MAX) return NULL;
 	dst = ln_arena_alloc(vm->arena, n + 1);
 	if (!dst) return NULL;
 	for (i = 0; i < n; i++) {
@@ -1148,7 +1152,9 @@ json_parse_object(ln_json_ctx_t *c, int depth)
 		 * overflow rather than silently dropping the segment, which would
 		 * mislabel this leaf under the parent/root key = silent corruption. */
 		c->key_len = saved_len;
-		if (saved_len + 1 + klen >= LN_JSON_KEYBUF) return -1;
+		if (klen >= LN_JSON_KEYBUF || saved_len + 1 + klen >= LN_JSON_KEYBUF)
+			return -1;   /* klen is input-derived: reject it alone first so the
+			              * sum below cannot size_t-wrap past the bound */
 		if (saved_len > 0) c->key[c->key_len++] = '.';
 		memcpy(c->key + c->key_len, kstr, klen);
 		c->key_len += klen;
@@ -1439,6 +1445,8 @@ vm_exec_instr(ln_vm_t *vm)
 
 	case OP_LITERAL: {
 		uint16_t len = inst->aux;
+		/* Bound inline compare to the 60-byte union (security audit #6b). */
+		if (len > LN_INSTR_MAX_INLINE) return -1;
 		if (remaining < len) return -1;
 		if (memcmp(vm->ip, inst->data.str, len) != 0) return -1;
 		vm->ip += len;
@@ -1448,6 +1456,8 @@ vm_exec_instr(ln_vm_t *vm)
 
 	case OP_LITERAL_CI: {
 		uint16_t len = inst->aux;
+		/* Bound inline compare to the 60-byte union (security audit #6b). */
+		if (len > LN_INSTR_MAX_INLINE) return -1;
 		if (remaining < len) return -1;
 		for (uint16_t i = 0; i < len; i++) {
 			if (tolower((unsigned char)vm->ip[i]) !=
@@ -2458,6 +2468,27 @@ ln_vm_continue(ln_vm_t *vm)
 	#define INST()       (&prog->code[pc])
 	#define WRITEBACK()  do { vm->pc = pc; vm->ip = ip; } while(0)
 
+	/*
+	 * VALIDATE_TARGET (security audit #5): compute a control-flow target
+	 * (jump/fork/call/ret) in int64_t and range-check it against
+	 * [0, code_len) BEFORE it is used or pushed. This prevents a crafted
+	 * relative offset from wrapping uint32_t arithmetic back into a
+	 * valid-looking-but-wrong pc. The DISPATCH bounds guard is the
+	 * backstop; this yields a clean error at the offending site.
+	 * `_t64` is the int64_t target expression; on success `_dst` (a
+	 * uint32_t lvalue) receives the validated value.
+	 */
+	#define VALIDATE_TARGET(_dst, _t64) \
+		do { \
+			int64_t _tt = (_t64); \
+			if (UNLIKELY(_tt < 0 || (uint64_t)_tt >= prog->code_len)) { \
+				vm->error = "control-flow target out of bounds"; \
+				WRITEBACK(); \
+				return LN_VM_ERROR; \
+			} \
+			(_dst) = (uint32_t)_tt; \
+		} while (0)
+
 	/* Start dispatch */
 	DISPATCH();
 
@@ -2481,16 +2512,14 @@ ln_vm_continue(ln_vm_t *vm)
 
 	CASE(jump) {
 		const ln_instr_t *inst = INST();
-		vm->instr_count++;
-		pc += inst->data.jump.offset;
+		VALIDATE_TARGET(pc, (int64_t)pc + inst->data.jump.offset);
 		DISPATCH();
 	}
 
 	CASE(fork) {
 		const ln_instr_t *inst = INST();
 		uint32_t alt_pc;
-		vm->instr_count++;
-		alt_pc = pc + inst->data.jump.offset;
+		VALIDATE_TARGET(alt_pc, (int64_t)pc + inst->data.jump.offset);
 		vm->pc = pc; vm->ip = ip; /* push_fork reads vm state */
 		if (UNLIKELY(!vm_push_fork(vm, alt_pc))) {
 			WRITEBACK();
@@ -2506,26 +2535,30 @@ ln_vm_continue(ln_vm_t *vm)
 
 	CASE(call) {
 		const ln_instr_t *inst;
-		vm->instr_count++;
+		uint32_t ret_pc, target_pc;
 		if (UNLIKELY(vm->call_sp >= LN_VM_MAX_CALLS)) {
 			vm->error = "call stack overflow";
 			WRITEBACK();
 			BACKTRACK();
 		}
 		inst = INST();
-		vm->calls[vm->call_sp++] = pc + 1;
-		pc += inst->data.jump.offset;
+		/* Validate both the return addr (pc+1) and the call target
+		 * before mutating the call stack (security audit #5). */
+		VALIDATE_TARGET(ret_pc, (int64_t)pc + 1);
+		VALIDATE_TARGET(target_pc, (int64_t)pc + inst->data.jump.offset);
+		vm->calls[vm->call_sp++] = ret_pc;
+		pc = target_pc;
 		DISPATCH();
 	}
 
 	CASE(ret) {
-		vm->instr_count++;
 		if (UNLIKELY(vm->call_sp == 0)) {
 			vm->error = "call stack underflow";
 			WRITEBACK();
 			BACKTRACK();
 		}
-		pc = vm->calls[--vm->call_sp];
+		/* Validate the popped return target (security audit #5). */
+		VALIDATE_TARGET(pc, (int64_t)vm->calls[--vm->call_sp]);
 		DISPATCH();
 	}
 
@@ -2535,7 +2568,6 @@ ln_vm_continue(ln_vm_t *vm)
 
 	CASE(ctx_push) {
 		const ln_instr_t *inst = INST();
-		vm->instr_count++;
 		if (UNLIKELY(!vm_push_field_ctx(vm, inst->data.str, false))) {
 			WRITEBACK();
 			BACKTRACK();
@@ -2544,7 +2576,6 @@ ln_vm_continue(ln_vm_t *vm)
 	}
 
 	CASE(ctx_pop) {
-		vm->instr_count++;
 		if (UNLIKELY(!vm_pop_field_ctx(vm))) {
 			WRITEBACK();
 			BACKTRACK();
@@ -2555,7 +2586,6 @@ ln_vm_continue(ln_vm_t *vm)
 
 	CASE(ctx_nest) {
 		const ln_instr_t *inst = INST();
-		vm->instr_count++;
 		if (UNLIKELY(!vm_push_field_ctx(vm, inst->data.str, true))) {
 			WRITEBACK();
 			BACKTRACK();
@@ -2565,7 +2595,6 @@ ln_vm_continue(ln_vm_t *vm)
 	}
 
 	CASE(ctx_unnest) {
-		vm->instr_count++;
 		if (UNLIKELY(!vm_pop_field_ctx(vm))) {
 			WRITEBACK();
 			BACKTRACK();
@@ -2581,8 +2610,13 @@ ln_vm_continue(ln_vm_t *vm)
 	CASE(literal) {
 		const ln_instr_t *inst = INST();
 		uint16_t len;
-		vm->instr_count++;
 		len = inst->aux;
+		/* Inline literals live in the 60-byte union; a malformed aux must
+		 * not let memcmp over-read past data.str (security audit #6b). */
+		if (UNLIKELY(len > LN_INSTR_MAX_INLINE)) {
+			WRITEBACK();
+			BACKTRACK();
+		}
 		if (UNLIKELY(REMAINING() < len)) {
 			WRITEBACK();
 			BACKTRACK();
@@ -2606,8 +2640,12 @@ ln_vm_continue(ln_vm_t *vm)
 	CASE(literal_ci) {
 		const ln_instr_t *inst = INST();
 		uint16_t len;
-		vm->instr_count++;
 		len = inst->aux;
+		/* Bound the inline compare to the 60-byte union (security audit #6b). */
+		if (UNLIKELY(len > LN_INSTR_MAX_INLINE)) {
+			WRITEBACK();
+			BACKTRACK();
+		}
 		if (UNLIKELY(REMAINING() < len)) {
 			WRITEBACK();
 			BACKTRACK();
@@ -2625,7 +2663,6 @@ ln_vm_continue(ln_vm_t *vm)
 	}
 
 	CASE(char) {
-		vm->instr_count++;
 		if (UNLIKELY(REMAINING() < 1)) {
 			WRITEBACK();
 			BACKTRACK();
@@ -2640,7 +2677,6 @@ ln_vm_continue(ln_vm_t *vm)
 	}
 
 	CASE(any) {
-		vm->instr_count++;
 		if (UNLIKELY(REMAINING() < 1)) {
 			WRITEBACK();
 			BACKTRACK();
@@ -2663,7 +2699,6 @@ ln_vm_continue(ln_vm_t *vm)
 	CASE(field_word) {
 		const ln_instr_t *inst = INST();
 		ln_span_t span;
-		vm->instr_count++;
 		if (UNLIKELY(ln_simd_word(ip, REMAINING(), &span) != LN_SIMD_OK)) {
 			WRITEBACK();
 			BACKTRACK();
@@ -2679,7 +2714,6 @@ ln_vm_continue(ln_vm_t *vm)
 		const ln_instr_t *inst = INST();
 		int64_t value;
 		size_t len;
-		vm->instr_count++;
 		if (UNLIKELY(parse_number(ip, REMAINING(), &value, &len) != 0)) {
 			WRITEBACK();
 			BACKTRACK();
@@ -2695,7 +2729,6 @@ ln_vm_continue(ln_vm_t *vm)
 		const ln_instr_t *inst = INST();
 		int64_t value;
 		size_t len;
-		vm->instr_count++;
 		if (UNLIKELY(parse_number(ip, REMAINING(), &value, &len) != 0)) {
 			WRITEBACK();
 			BACKTRACK();
@@ -2714,7 +2747,6 @@ ln_vm_continue(ln_vm_t *vm)
 	CASE(field_float) {
 		const ln_instr_t *inst = INST();
 		size_t len;
-		vm->instr_count++;
 		if (UNLIKELY(parse_float(ip, REMAINING(), &len) != 0)) {
 			WRITEBACK();
 			BACKTRACK();
@@ -2729,7 +2761,6 @@ ln_vm_continue(ln_vm_t *vm)
 	CASE(field_ipv4) {
 		const ln_instr_t *inst = INST();
 		size_t len;
-		vm->instr_count++;
 		if (UNLIKELY(parse_ipv4(ip, REMAINING(), &len) != 0)) {
 			WRITEBACK();
 			BACKTRACK();
@@ -2744,7 +2775,6 @@ ln_vm_continue(ln_vm_t *vm)
 	CASE(field_ipv6) {
 		const ln_instr_t *inst = INST();
 		size_t len;
-		vm->instr_count++;
 		if (UNLIKELY(parse_ipv6(ip, REMAINING(), &len) != 0)) {
 			WRITEBACK();
 			BACKTRACK();
@@ -2760,7 +2790,6 @@ ln_vm_continue(ln_vm_t *vm)
 		const ln_instr_t *inst = INST();
 		int64_t value;
 		size_t len;
-		vm->instr_count++;
 		if (UNLIKELY(parse_hex(ip, REMAINING(), &value, &len) != 0)) {
 			WRITEBACK();
 			BACKTRACK();
@@ -2775,7 +2804,6 @@ ln_vm_continue(ln_vm_t *vm)
 	CASE(field_quoted) {
 		const ln_instr_t *inst = INST();
 		size_t start, len, consumed;
-		vm->instr_count++;
 		if (UNLIKELY(parse_op_quoted(ip, REMAINING(), &start, &len, &consumed) != 0)) {
 			WRITEBACK();
 			BACKTRACK();
@@ -2791,7 +2819,6 @@ ln_vm_continue(ln_vm_t *vm)
 		const ln_instr_t *inst = INST();
 		char delim;
 		ln_span_t span;
-		vm->instr_count++;
 		delim = (char)inst->data.char_to.delim;
 		if (UNLIKELY(ln_simd_char_to(ip, REMAINING(), delim, &span) != LN_SIMD_OK)) {
 			WRITEBACK();
@@ -2808,7 +2835,6 @@ ln_vm_continue(ln_vm_t *vm)
 		const ln_instr_t *inst = INST();
 		char delim;
 		size_t len;
-		vm->instr_count++;
 		delim = (char)inst->data.char_to.delim;
 		if (UNLIKELY(parse_char_to(ip, REMAINING(), delim, &len) != 0)) {
 			WRITEBACK();
@@ -2824,7 +2850,6 @@ ln_vm_continue(ln_vm_t *vm)
 	CASE(field_rest) {
 		const ln_instr_t *inst = INST();
 		size_t rem;
-		vm->instr_count++;
 		rem = REMAINING();
 		vm->ip = ip;
 		vm_add_string_field(vm, inst->data.str, ip, rem);
@@ -2836,7 +2861,6 @@ ln_vm_continue(ln_vm_t *vm)
 	CASE(field_json) {
 		const ln_instr_t *inst = INST();
 		size_t len;
-		vm->instr_count++;
 		vm->ip = ip;
 		/* SIMD stage-1 structural scan + scalar stage-2 flatten.
 		 * On parse failure BACKTRACK restores result->n_fields from the
@@ -2854,7 +2878,6 @@ ln_vm_continue(ln_vm_t *vm)
 	CASE(field_mac) {
 		const ln_instr_t *inst = INST();
 		size_t len;
-		vm->instr_count++;
 		if (UNLIKELY(parse_mac48(ip, REMAINING(), &len) != 0)) {
 			WRITEBACK();
 			BACKTRACK();
@@ -2869,7 +2892,6 @@ ln_vm_continue(ln_vm_t *vm)
 	CASE(field_date) {
 		const ln_instr_t *inst = INST();
 		ln_span_t span;
-		vm->instr_count++;
 		if (UNLIKELY(ln_simd_timestamp(ip, REMAINING(), &span, NULL) != LN_SIMD_OK)) {
 			WRITEBACK();
 			BACKTRACK();
@@ -2904,7 +2926,6 @@ ln_vm_continue(ln_vm_t *vm)
 		int ignore_ws;
 		int n_pairs;
 
-		vm->instr_count++;
 		vm->ip = ip;
 		vm->pc = pc;
 
@@ -3050,7 +3071,6 @@ ln_vm_continue(ln_vm_t *vm)
 	 *=================================================================*/
 
 	CASE(skip_space) {
-		vm->instr_count++;
 		ip += ln_simd_skip_space(ip, REMAINING());
 		pc++;
 		DISPATCH();
@@ -3059,7 +3079,6 @@ ln_vm_continue(ln_vm_t *vm)
 	CASE(skip_space1) {
 		size_t rem;
 		size_t skipped;
-		vm->instr_count++;
 		rem = REMAINING();
 		if (UNLIKELY(rem == 0 || !isspace((unsigned char)ip[0]))) {
 			WRITEBACK();
@@ -3076,7 +3095,6 @@ ln_vm_continue(ln_vm_t *vm)
 	CASE(skip_n) {
 		const ln_instr_t *inst = INST();
 		uint16_t n;
-		vm->instr_count++;
 		n = inst->aux;
 		if (UNLIKELY(REMAINING() < n)) {
 			WRITEBACK();
@@ -3092,7 +3110,6 @@ ln_vm_continue(ln_vm_t *vm)
 		char c;
 		size_t rem;
 		size_t pos;
-		vm->instr_count++;
 		c = inst->data.str[0];
 		rem = REMAINING();
 		pos = ln_simd_find_char(ip, rem, c);
@@ -3110,7 +3127,6 @@ ln_vm_continue(ln_vm_t *vm)
 		char c;
 		size_t rem;
 		size_t pos;
-		vm->instr_count++;
 		c = inst->data.str[0];
 		rem = REMAINING();
 		pos = ln_simd_find_char(ip, rem, c);
@@ -3126,7 +3142,6 @@ ln_vm_continue(ln_vm_t *vm)
 	CASE(skip_line) {
 		size_t rem;
 		size_t pos;
-		vm->instr_count++;
 		rem = REMAINING();
 		pos = ln_simd_find_char(ip, rem, '\n');
 		ip += (pos < rem) ? pos + 1 : rem;
@@ -3140,7 +3155,6 @@ ln_vm_continue(ln_vm_t *vm)
 
 	CASE(tag) {
 		const ln_instr_t *inst = INST();
-		vm->instr_count++;
 		if (vm->result && inst->data.str[0]) {
 			ln_fast_add_tag(vm->result, inst->data.str);
 		}
@@ -3150,7 +3164,6 @@ ln_vm_continue(ln_vm_t *vm)
 
 	CASE(rule_id) {
 		const ln_instr_t *inst = INST();
-		vm->instr_count++;
 		if (vm->result && inst->data.str[0]) {
 			ln_fast_set_rule_id(vm->result, inst->data.str);
 		}
@@ -3160,7 +3173,6 @@ ln_vm_continue(ln_vm_t *vm)
 
 	CASE(static_field) {
 		const ln_instr_t *inst = INST();
-		vm->instr_count++;
 		if (vm->result && inst->data.kv.key[0]) {
 			uint16_t klen = inst->aux;
 			size_t vlen = strlen(inst->data.kv.val);
@@ -3177,7 +3189,6 @@ ln_vm_continue(ln_vm_t *vm)
 	 *=================================================================*/
 
 	CASE(assert_char) {
-		vm->instr_count++;
 		if (UNLIKELY(REMAINING() < 1 || *ip != INST()->data.str[0])) {
 			WRITEBACK();
 			BACKTRACK();
@@ -3187,7 +3198,6 @@ ln_vm_continue(ln_vm_t *vm)
 	}
 
 	CASE(assert_end) {
-		vm->instr_count++;
 		if (UNLIKELY(REMAINING() > 0)) {
 			WRITEBACK();
 			BACKTRACK();
@@ -3197,7 +3207,6 @@ ln_vm_continue(ln_vm_t *vm)
 	}
 
 	CASE(assert_start) {
-		vm->instr_count++;
 		if (UNLIKELY(ip != vm->input)) {
 			WRITEBACK();
 			BACKTRACK();
@@ -3215,7 +3224,6 @@ ln_vm_continue(ln_vm_t *vm)
 		const char *p;
 		uint32_t pri;
 		int digits;
-		vm->instr_count++;
 		rem = REMAINING();
 		if (UNLIKELY(rem < 3 || ip[0] != '<')) {
 			WRITEBACK();
@@ -3247,7 +3255,6 @@ ln_vm_continue(ln_vm_t *vm)
 		const ln_instr_t *inst = INST();
 		ln_span_t span;
 		const char *name;
-		vm->instr_count++;
 		if (UNLIKELY(ln_simd_timestamp(ip, REMAINING(), &span, NULL) != LN_SIMD_OK)) {
 			WRITEBACK();
 			BACKTRACK();
@@ -3276,7 +3283,6 @@ ln_vm_continue(ln_vm_t *vm)
 			"SignatureID", "Name", "Severity"
 		};
 
-		vm->instr_count++;
 		vm->ip = ip;
 		vm->pc = pc;
 
@@ -3415,7 +3421,6 @@ ln_vm_continue(ln_vm_t *vm)
 		const char *p;
 		int n_pairs;
 
-		vm->instr_count++;
 		vm->ip = ip;
 		vm->pc = pc;
 
@@ -3538,7 +3543,6 @@ ln_vm_continue(ln_vm_t *vm)
 		size_t rem;
 		size_t json_len;
 
-		vm->instr_count++;
 
 		fname = inst->data.str;
 		rem = REMAINING();
@@ -3594,7 +3598,6 @@ ln_vm_continue(ln_vm_t *vm)
 		const char *p;
 		int n_pairs;
 
-		vm->instr_count++;
 		vm->ip = ip;
 		vm->pc = pc;
 
@@ -3679,13 +3682,11 @@ ln_vm_continue(ln_vm_t *vm)
 	 *=================================================================*/
 
 	CASE(nop) {
-		vm->instr_count++;
 		pc++;
 		DISPATCH();
 	}
 
 	CASE(debug) {
-		vm->instr_count++;
 		WRITEBACK();
 		fprintf(stderr, "[DEBUG] pc=%u ip=%zu ctx_sp=%u\n",
 				pc, (size_t)(ip - vm->input), vm->field_ctx_sp);
@@ -3723,6 +3724,7 @@ backtrack:
 	#undef REMAINING
 	#undef INST
 	#undef WRITEBACK
+	#undef VALIDATE_TARGET
 }
 
 #else /* !LN_VM_COMPUTED_GOTO — switch-based fallback */

--- a/src/turbo_vm.c
+++ b/src/turbo_vm.c
@@ -1007,8 +1007,13 @@ json_emit_bool(ln_json_ctx_t *c, bool v)
 static int json_parse_value(ln_json_ctx_t *c, int depth);
 
 /*
- * Parse a JSON number at ctx->pos. Decides int vs double by presence of
- * '.', 'e' or 'E'. Emits via json_emit_int / json_emit_double.
+ * Parse a JSON number at ctx->pos with a strict JSON-grammar validator:
+ *   optional leading '-', required integer digits, optional '.'+frac digits,
+ *   optional 'e'/'E' (+/-) exp digits. Returns -1 on any invalid form
+ *   (lone '-'/'.', '+'-prefix, multiple '.'/'e', sign mid-number, ...) WITHOUT
+ *   advancing the cursor, so the caller backtracks the whole line instead of
+ *   mis-consuming garbage. On success advances pos by exactly the validated
+ *   length. Decides int vs double by presence of '.', 'e' or 'E'.
  */
 static int
 json_parse_number(ln_json_ctx_t *c)
@@ -1018,16 +1023,30 @@ json_parse_number(ln_json_ctx_t *c)
 	size_t i = 0;
 	bool is_double = false;
 
-	if (i < rem && (s[i] == '-' || s[i] == '+')) i++;
-	while (i < rem) {
-		char ch = s[i];
-		if (ch >= '0' && ch <= '9') { i++; continue; }
-		if (ch == '.' || ch == 'e' || ch == 'E' || ch == '+' || ch == '-') {
-			is_double = true; i++; continue;
-		}
-		break;
+	if (i < rem && s[i] == '-') i++;        /* JSON allows leading '-' only */
+
+	{
+		size_t int_start = i;
+		while (i < rem && s[i] >= '0' && s[i] <= '9') i++;
+		if (i == int_start) return -1;      /* integer digits required */
 	}
-	if (i == 0) return -1;
+
+	if (i < rem && s[i] == '.') {
+		size_t frac_start;
+		is_double = true; i++;
+		frac_start = i;
+		while (i < rem && s[i] >= '0' && s[i] <= '9') i++;
+		if (i == frac_start) return -1;     /* '.' must be followed by digits */
+	}
+
+	if (i < rem && (s[i] == 'e' || s[i] == 'E')) {
+		size_t exp_start;
+		is_double = true; i++;
+		if (i < rem && (s[i] == '+' || s[i] == '-')) i++;
+		exp_start = i;
+		while (i < rem && s[i] >= '0' && s[i] <= '9') i++;
+		if (i == exp_start) return -1;      /* exponent digits required */
+	}
 
 	if (is_double) {
 		char tmp[64];
@@ -1071,13 +1090,14 @@ json_parse_object(ln_json_ctx_t *c, int depth)
 		c->pos++;                                   /* opening quote */
 		if (json_scan_string(c, &kstr, &klen) != 0) return -1;
 
-		/* append ".<key>" to dotted path (truncate silently if it overflows) */
+		/* append ".<key>" to dotted path; fail (backtrack the line) on
+		 * overflow rather than silently dropping the segment, which would
+		 * mislabel this leaf under the parent/root key = silent corruption. */
 		c->key_len = saved_len;
-		if (saved_len + 1 + klen < LN_JSON_KEYBUF) {
-			if (saved_len > 0) c->key[c->key_len++] = '.';
-			memcpy(c->key + c->key_len, kstr, klen);
-			c->key_len += klen;
-		}
+		if (saved_len + 1 + klen >= LN_JSON_KEYBUF) return -1;
+		if (saved_len > 0) c->key[c->key_len++] = '.';
+		memcpy(c->key + c->key_len, kstr, klen);
+		c->key_len += klen;
 
 		json_skip_ws(c);
 		if (c->pos >= c->len || c->buf[c->pos] != ':') return -1;
@@ -1117,13 +1137,13 @@ json_parse_array(ln_json_ctx_t *c, int depth)
 		json_skip_ws(c);
 		if (c->pos >= c->len) return -1;
 
-		/* index-suffix key for scalar elements */
+		/* index-suffix key for scalar elements; fail (backtrack the line)
+		 * on overflow rather than silently mislabelling the element. */
 		c->key_len = saved_len;
 		n = snprintf(ib, sizeof(ib), ".%d", idx);
-		if (n > 0 && saved_len + (size_t)n < LN_JSON_KEYBUF) {
-			memcpy(c->key + c->key_len, ib, (size_t)n);
-			c->key_len += (size_t)n;
-		}
+		if (n <= 0 || saved_len + (size_t)n >= LN_JSON_KEYBUF) return -1;
+		memcpy(c->key + c->key_len, ib, (size_t)n);
+		c->key_len += (size_t)n;
 
 		if (json_parse_value(c, depth + 1) != 0) return -1;
 		c->key_len = saved_len;
@@ -1211,7 +1231,11 @@ vm_json_flatten(ln_vm_t *vm, const char *field_name,
 	/* Seed the dotted prefix with the (context-resolved) field name so the
 	 * flattened leaves nest under it, exactly like vm_add_string_field. */
 	full_name = vm_build_field_name(vm, field_name, &fn_len);
-	if (full_name && full_name[0] && fn_len < LN_JSON_KEYBUF) {
+	if (full_name && full_name[0]) {
+		/* Fail (backtrack the line) if the seed prefix alone overflows the
+		 * key buffer rather than emitting every leaf under a truncated /
+		 * empty root = silent corruption. */
+		if (fn_len >= LN_JSON_KEYBUF) return -1;
 		memcpy(c.key, full_name, fn_len);
 		c.key_len = fn_len;
 	}

--- a/src/turbo_vm.c
+++ b/src/turbo_vm.c
@@ -24,6 +24,10 @@
  *
  * A copy of the LGPL v2.1 can be found in the file "COPYING" in this distribution.
  */
+/* config.h MUST precede the system headers: it defines _GNU_SOURCE, which is what
+ * makes glibc's <stdlib.h> declare strtod_l (modern glibc has no <xlocale.h>).
+ * FreeBSD/macOS declare strtod_l in <xlocale.h>, included below. */
+#include "config.h"
 #include "turbo_vm.h"
 #include "turbo_vm_opt.h"
 #include "turbo_simd.h"
@@ -32,6 +36,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <locale.h>
+#if defined(__has_include)
+# if __has_include(<xlocale.h>)
+#  include <xlocale.h>
+# endif
+#endif
 
 /*============================================================================
  * Debug Tracing
@@ -942,7 +952,10 @@ json_unescape_arena(ln_vm_t *vm, const char *s, size_t n, size_t *out_len)
 						break;
 					}
 				}
-				dst[o++] = 'u';   /* malformed \u: emit literally */
+				/* malformed \u: emit the backslash + 'u' literally; the
+				 * hex-ish bytes that follow are emitted as normal chars. */
+				dst[o++] = '\\';
+				dst[o++] = 'u';
 				break;
 			}
 			default: dst[o++] = e; break;
@@ -997,18 +1010,45 @@ json_emit_double(ln_json_ctx_t *c, double v)
 		c->n_emitted++;
 }
 
+/* JSON numbers always use '.' as the decimal separator, but strtod() honours the
+ * process LC_NUMERIC, so in a comma-decimal locale (de_DE, fr_FR, ...) it would
+ * parse "1.5" as 1.0 -- silently corrupting the value and diverging from the v1
+ * path (libfastjson, which is locale-independent). We parse through a private C
+ * locale (strtod_l) instead. The locale is an immutable process-global resource:
+ * created once at library load, before any thread starts, and never modified, so
+ * sharing it across threads needs no locking. */
+static locale_t turbo_c_locale;
+
+__attribute__((constructor))
+static void turbo_c_locale_init(void)
+{
+	turbo_c_locale = newlocale(LC_NUMERIC_MASK, "C", (locale_t)0);
+}
+
+__attribute__((destructor))
+static void turbo_c_locale_fini(void)
+{
+	if (turbo_c_locale != (locale_t)0) {
+		freelocale(turbo_c_locale);
+		turbo_c_locale = (locale_t)0;
+	}
+}
+
 /*
  * Emit s[0..len) (an already grammar-validated JSON number span) as a double.
  * The common case fits the stack buffer; a pathologically long number is copied
- * in full via the VM arena before strtod, because truncating to the stack buffer
- * could cut a trailing 'eNN' exponent and silently corrupt the magnitude. strtod
- * saturates out-of-range values to +/-HUGE_VAL per C, which is acceptable here.
+ * in full via the VM arena, because truncating to the stack buffer could cut a
+ * trailing 'eNN' exponent and silently corrupt the magnitude. Parsing goes
+ * through the private C locale (strtod_l) so the decimal point is always '.'
+ * regardless of the process locale; out-of-range values saturate to +/-HUGE_VAL
+ * per C, which is acceptable here.
  */
 static void
 json_emit_double_span(ln_json_ctx_t *c, const char *s, size_t len)
 {
 	char stackbuf[64];
 	const char *num;
+	double v;
 
 	if (len < sizeof(stackbuf)) {
 		memcpy(stackbuf, s, len);
@@ -1018,7 +1058,11 @@ json_emit_double_span(ln_json_ctx_t *c, const char *s, size_t len)
 		num = ln_arena_strndup(c->vm->arena, s, len);
 		if (num == NULL) return;   /* OOM: drop this field, keep the line */
 	}
-	json_emit_double(c, strtod(num, NULL));
+	/* Plain strtod only as a fallback if newlocale() failed at load (OOM). */
+	v = (turbo_c_locale != (locale_t)0)
+		? strtod_l(num, NULL, turbo_c_locale)
+		: strtod(num, NULL);
+	json_emit_double(c, v);
 }
 
 /* bool emitted as the STRING "true"/"false" (string-store convention). */

--- a/src/turbo_vm.c
+++ b/src/turbo_vm.c
@@ -997,6 +997,30 @@ json_emit_double(ln_json_ctx_t *c, double v)
 		c->n_emitted++;
 }
 
+/*
+ * Emit s[0..len) (an already grammar-validated JSON number span) as a double.
+ * The common case fits the stack buffer; a pathologically long number is copied
+ * in full via the VM arena before strtod, because truncating to the stack buffer
+ * could cut a trailing 'eNN' exponent and silently corrupt the magnitude. strtod
+ * saturates out-of-range values to +/-HUGE_VAL per C, which is acceptable here.
+ */
+static void
+json_emit_double_span(ln_json_ctx_t *c, const char *s, size_t len)
+{
+	char stackbuf[64];
+	const char *num;
+
+	if (len < sizeof(stackbuf)) {
+		memcpy(stackbuf, s, len);
+		stackbuf[len] = '\0';
+		num = stackbuf;
+	} else {
+		num = ln_arena_strndup(c->vm->arena, s, len);
+		if (num == NULL) return;   /* OOM: drop this field, keep the line */
+	}
+	json_emit_double(c, strtod(num, NULL));
+}
+
 /* bool emitted as the STRING "true"/"false" (string-store convention). */
 static void
 json_emit_bool(ln_json_ctx_t *c, bool v)
@@ -1049,22 +1073,15 @@ json_parse_number(ln_json_ctx_t *c)
 	}
 
 	if (is_double) {
-		char tmp[64];
-		size_t cl = i < sizeof(tmp) - 1 ? i : sizeof(tmp) - 1;
-		memcpy(tmp, s, cl); tmp[cl] = '\0';
-		json_emit_double(c, strtod(tmp, NULL));
+		json_emit_double_span(c, s, i);
 	} else {
 		int64_t v;
 		size_t consumed;
 		if (parse_number(s, i, &v, &consumed) == 0)
 			json_emit_int(c, v);
-		else {
-			/* overflow / too-long int: keep as double for fidelity */
-			char tmp[64];
-			size_t cl = i < sizeof(tmp) - 1 ? i : sizeof(tmp) - 1;
-			memcpy(tmp, s, cl); tmp[cl] = '\0';
-			json_emit_double(c, strtod(tmp, NULL));
-		}
+		else
+			/* overflow / too-long int: keep full span as double for fidelity */
+			json_emit_double_span(c, s, i);
 	}
 	c->pos += i;
 	return 0;

--- a/src/turbo_vm.h
+++ b/src/turbo_vm.h
@@ -112,6 +112,10 @@ typedef struct {
 	/* Output - FAST RESULT */
 	ln_fast_result_t *result;   /**< Parse result (optimized) */
 	ln_arena_t  *arena;         /**< Arena for overflow storage */
+	void        *c_locale;      /**< C locale_t for locale-independent number
+	                              *  parsing (strtod_l); owned, created in
+	                              *  ln_vm_init, freed in ln_vm_destroy. void* so
+	                              *  this header needs no <locale.h>. */
 
 	/* Statistics */
 	uint64_t    instr_count;    /**< Instructions executed */
@@ -130,6 +134,7 @@ typedef struct {
  *============================================================================*/
 
 int ln_vm_init(ln_vm_t *vm, ln_arena_t *arena);
+void ln_vm_destroy(ln_vm_t *vm);
 void ln_vm_reset(ln_vm_t *vm);
 
 /*============================================================================

--- a/src/turbo_vm_opt.h
+++ b/src/turbo_vm_opt.h
@@ -140,9 +140,30 @@
  * DISPATCH: jump to the handler for the current instruction at pc.
  * The prefetch of the NEXT instruction's cache line overlaps with
  * the current handler's execution.
+ *
+ * Two safety guards run before every fetch (security audit #4, #7):
+ *   - PC bounds: a program that runs off the end (e.g. missing HALT,
+ *     or a wild jump target) must not perform an OOB read of
+ *     prog->code[pc] and a wild indirect jump. This restores parity
+ *     with the legacy switch path (vm_exec_instr), which guards pc.
+ *   - Instruction limit: an always-succeeding self-loop (e.g. JUMP
+ *     offset=0) never reaches the backtrack: label, so the limit must
+ *     be enforced here on the dispatch path to bound execution.
+ *
+ * Requires `vm` and `MAX_INSTRUCTIONS` in scope (ln_vm_continue).
  */
 #define DISPATCH() \
 	do { \
+		if (UNLIKELY(pc >= prog->code_len)) { \
+			vm->pc = pc; vm->ip = ip; \
+			vm->error = "PC out of bounds"; \
+			return LN_VM_ERROR; \
+		} \
+		if (UNLIKELY(++vm->instr_count > MAX_INSTRUCTIONS)) { \
+			vm->pc = pc; vm->ip = ip; \
+			vm->error = "instruction limit exceeded"; \
+			return LN_VM_LIMIT; \
+		} \
 		PREFETCH(&prog->code[pc + 1]); \
 		goto *dispatch_table[prog->code[pc].op]; \
 	} while (0)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,7 @@
 check_PROGRAMS = json_eq err_callback_cookie
 TESTS_TURBO_SHELLS = \
-	turbo_smoke.sh
+	turbo_smoke.sh \
+	field_name_value_whitespace_turbo.sh
 
 # re-enable if we really need the c program check check_PROGRAMS = json_eq user_test
 json_eq_self_sources = json_eq.c

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,7 +1,8 @@
 check_PROGRAMS = json_eq err_callback_cookie
 TESTS_TURBO_SHELLS = \
 	turbo_smoke.sh \
-	field_name_value_whitespace_turbo.sh
+	field_name_value_whitespace_turbo.sh \
+	field_json_turbo.sh
 
 # re-enable if we really need the c program check check_PROGRAMS = json_eq user_test
 json_eq_self_sources = json_eq.c

--- a/tests/field_json_turbo.sh
+++ b/tests/field_json_turbo.sh
@@ -42,4 +42,56 @@ add_rule 'rule=:%field:json%'
 execute '{"f1": "1", f2: 2}'
 assert_output_json_eq '{ "unparsed-data": "{\"f1\": \"1\", f2: 2}" }'
 
+# Strict JSON-number validation: malformed numbers must FAIL the turbo parse
+# (return -1 -> backtrack) rather than mis-consume invalid bytes as a single
+# number. Pre-fix the turbo scanner silently consumed "1+2-3" as one number
+# (strtod -> 1.0), MATCHING with a corrupt value and mis-parsing what followed;
+# lone "-"/"." became 0.0. Turbo now rejects these. lognormalizer's v1 walker
+# also rejects the forms tested below, so the end-to-end result is unparsed-data.
+# (A few turbo-rejected forms like "1." / "1e" / "01" are accepted by the
+# lenient v1 path and would still match here, so this test uses only forms
+# rejected by both paths.)
+reset_rules
+add_rule 'version=2'
+add_rule 'rule=:%field:json%'
+
+# multiple sign/operator characters mid-number -> reject (was mis-consumed)
+execute '{"n": 1+2-3}'
+assert_output_json_eq '{ "unparsed-data": "{\"n\": 1+2-3}" }'
+
+# lone '-' is not a valid number -> reject (was 0.0)
+execute '{"n": -}'
+assert_output_json_eq '{ "unparsed-data": "{\"n\": -}" }'
+
+# lone '.' is not a valid number -> reject (was 0.0)
+execute '{"n": .}'
+assert_output_json_eq '{ "unparsed-data": "{\"n\": .}" }'
+
+# leading '+' is not valid JSON -> reject
+execute '{"n": +5}'
+assert_output_json_eq '{ "unparsed-data": "{\"n\": +5}" }'
+
+# bare '.' before fraction digits -> reject
+execute '{"n": .5}'
+assert_output_json_eq '{ "unparsed-data": "{\"n\": .5}" }'
+
+# two decimal points -> reject
+execute '{"n": 1.2.3}'
+assert_output_json_eq '{ "unparsed-data": "{\"n\": 1.2.3}" }'
+
+# double leading sign -> reject
+execute '{"n": --5}'
+assert_output_json_eq '{ "unparsed-data": "{\"n\": --5}" }'
+
+# Valid edge forms still parse correctly: negative int, fraction, signed exp.
+execute '{"a": -3, "b": 2.50, "c": 6.022e23}'
+assert_output_json_eq '{ "field": { "a": -3, "b": 2.5, "c": 6.022e23 } }'
+
+# Key-buffer overflow must FAIL the parse (backtrack), not silently mislabel the
+# leaf under a truncated key. A deeply-nested path whose dotted key exceeds the
+# 512-byte scratch buffer must not match.
+deep=$(python3 -c 'print("".join("{\"aaaaaaaaaaaaaaaa%d\":"%i for i in range(40)) + "1" + "}"*40)')
+execute "$deep"
+assert_output_contains 'unparsed-data'
+
 cleanup_tmp_files

--- a/tests/field_json_turbo.sh
+++ b/tests/field_json_turbo.sh
@@ -96,6 +96,18 @@ big=$(python3 -c 'print("1" + "0"*69)')
 execute "{\"big\": $big}"
 assert_output_json_eq '{ "field": { "big": 1e69 } }'
 
+# Locale-independence: the decimal separator is always '.' regardless of the
+# process LC_NUMERIC. Under a comma-decimal locale, plain strtod() would parse
+# "1.5" as 1.0; turbo parses via a private C locale (strtod_l) so it stays 1.5.
+# (Falls back to the C locale itself if de_DE is not installed -> still 1.5.)
+LC_ALL=de_DE.UTF-8 LC_NUMERIC=de_DE.UTF-8 execute '{"v": 1.5}'
+assert_output_json_eq '{ "field": { "v": 1.5 } }'
+
+# Malformed \u escape must be emitted literally INCLUDING its backslash (the old
+# code dropped the '\' and emitted only "u1z34"). The 'z' makes \u non-hex.
+execute '{"s": "\u1z34"}'
+assert_output_json_eq '{ "field": { "s": "\\u1z34" } }'
+
 # Key-buffer overflow must FAIL the parse (backtrack), not silently mislabel the
 # leaf under a truncated key. A deeply-nested path whose dotted key exceeds the
 # 512-byte scratch buffer must not match.

--- a/tests/field_json_turbo.sh
+++ b/tests/field_json_turbo.sh
@@ -87,6 +87,15 @@ assert_output_json_eq '{ "unparsed-data": "{\"n\": --5}" }'
 execute '{"a": -3, "b": 2.50, "c": 6.022e23}'
 assert_output_json_eq '{ "field": { "a": -3, "b": 2.5, "c": 6.022e23 } }'
 
+# Long number (span > the 64-byte stack buffer): must reach strtod IN FULL via
+# the arena path. The old code copied only the first 63 bytes before strtod, so
+# a long mantissa could be cut short of its trailing exponent and the magnitude
+# silently corrupted. This 70-digit integer overflows int64 -> kept as a double;
+# the value must round-trip to ~1e69, not the ~1e62 a 63-char truncation gives.
+big=$(python3 -c 'print("1" + "0"*69)')
+execute "{\"big\": $big}"
+assert_output_json_eq '{ "field": { "big": 1e69 } }'
+
 # Key-buffer overflow must FAIL the parse (backtrack), not silently mislabel the
 # leaf under a truncated key. A deeply-nested path whose dotted key exceeds the
 # 512-byte scratch buffer must not match.

--- a/tests/field_json_turbo.sh
+++ b/tests/field_json_turbo.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# TurboVM OP_FIELD_JSON flatten parity
+# This file is part of the liblognorm project, released under ASL 2.0
+#
+# Proves the TurboVM JSON field handler flattens into the flat store and
+# round-trips through the serializer to the SAME nested JSON the v1 parser
+# produces (no more whole-object stringification).
+srcdir="${srcdir:-.}"
+# shellcheck disable=SC1091
+. "$srcdir"/exec.sh
+
+export ln_opts='-oturbo'
+
+test_def "$0" "TurboVM JSON field flatten + parity"
+add_rule 'version=2'
+add_rule 'rule=:%field:json%'
+
+# Simple object: keys + types preserved (int 2, not "2").
+execute '{"f1": "1", "f2": 2}'
+assert_output_json_eq '{ "field": { "f1": "1", "f2": 2 } }'
+
+# Nested object: dotted flat keys re-nest; int leaf stays int.
+execute '{"outer": {"num": 3, "name": "value"}}'
+assert_output_json_eq '{ "field": { "outer": { "num": 3, "name": "value" } } }'
+
+# Mixed scalar types: int / double / bool / string.
+# NOTE: bool is emitted as the STRING "true"/"false" by design (string-store
+# convention); double compares with json_eq's 0.001 tolerance so 1.5 == 1.50.
+execute '{"i": 42, "d": 1.5, "b": true, "s": "x"}'
+assert_output_json_eq '{ "field": { "i": 42, "d": 1.5, "b": "true", "s": "x" } }'
+
+# Trailing data tolerated (v1 parity): parser consumes only the JSON span.
+add_rule 'rule=:%field:json%end'
+execute '{"f1": "1", "f2": 2}end'
+assert_output_json_eq '{ "field": { "f1": "1", "f2": 2 } }'
+
+# Parse failure must NOT match (backtrack): the JSON field rejects malformed
+# input just like v1 (turbo's no-match path emits only unparsed-data).
+reset_rules
+add_rule 'version=2'
+add_rule 'rule=:%field:json%'
+execute '{"f1": "1", f2: 2}'
+assert_output_json_eq '{ "unparsed-data": "{\"f1\": \"1\", f2: 2}" }'
+
+cleanup_tmp_files

--- a/tests/field_name_value_whitespace_turbo.sh
+++ b/tests/field_name_value_whitespace_turbo.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# TurboVM parity test for name-value-list "ignore_whitespaces".
+# Mirrors field_name_value_whitespace.sh but runs the rulebase through the
+# TurboVM bytecode engine (-oturbo); the expected output must be identical to
+# the standard parser.
+# This file is part of the liblognorm project, released under ASL 2.0
+srcdir="${srcdir:-.}"
+# shellcheck disable=SC1091
+. "$srcdir"/exec.sh
+
+export ln_opts='-oturbo'
+
+test_def "$0" "name/value parser (TurboVM, ignore_whitespaces)"
+add_rule 'version=2'
+add_rule 'rule=:%{"name":"f", "type":"name-value-list", "separator":",", "assignator":":", "ignore_whitespaces":true}%'
+
+execute 'name:value'
+assert_output_json_eq '{ "f": { "name": "value" } }'
+
+execute 'name1:value1,name2:value2,name3:value3'
+assert_output_json_eq '{ "f": { "name1": "value1", "name2": "value2", "name3": "value3" } }'
+
+execute ' name1: abcd, name2 : value2 ,name3 :value3 '
+assert_output_json_eq '{ "f": { "name1": "abcd", "name2": "value2", "name3": "value3" } }'
+
+execute 'name1:"value1" , name2 : "value2" , name3 : value3 '
+assert_output_json_eq '{ "f": { "name1": "value1", "name2": "value2", "name3": "value3" } }'
+
+execute 'name1:   , name2 : value2'
+assert_output_json_eq '{ "f": { "name1": "", "name2": "value2" } }'
+
+execute 'name1:   '
+assert_output_json_eq '{ "f": { "name1": "" } }'
+
+# Without ignore_whitespaces, TurboVM must preserve surrounding whitespace
+# (regression guard: the option-off path must not trim). The input avoids a
+# leading space on the message itself: trimming of the message's first
+# character is a separate, pre-existing TurboVM/standard difference unrelated
+# to this option.
+reset_rules
+add_rule 'version=2'
+add_rule 'rule=:%{"name":"f", "type":"name-value-list", "separator":",", "assignator":":"}%'
+
+execute 'name1 : abcd, name2 : value2 ,name3 :value3 '
+assert_output_json_eq '{ "f": { "name1 ": " abcd", " name2 ": " value2 ", "name3 ": "value3 " } }'
+
+cleanup_tmp_files

--- a/tests/turbo_test_arena.c
+++ b/tests/turbo_test_arena.c
@@ -757,6 +757,34 @@ static int test_macros(void)
     return 1;
 }
 
+static int test_alloc_array_overflow(void)
+{
+    ln_arena_t arena;
+    ln_arena_init(&arena);
+
+    /* Hostile element count: (SIZE_MAX/2 + 1) * 4 wraps a size_t multiply.
+     * The checked allocator must reject it rather than return a tiny slot. */
+    void *wrapped = ln_arena_alloc_array(&arena, SIZE_MAX / 2 + 1, 4);
+    TEST_ASSERT(wrapped == NULL, "overflowing array alloc should return NULL");
+
+    /* A normal allocation must still succeed and be a valid, distinct slot. */
+    int *ok1 = (int *)ln_arena_alloc_array(&arena, 10, sizeof(int));
+    TEST_ASSERT(ok1 != NULL, "valid array alloc should succeed");
+    for (int i = 0; i < 10; i++) ok1[i] = i;
+    TEST_ASSERT_EQ(ok1[9], 9, "array data should be writable/intact");
+
+    int *ok2 = (int *)ln_arena_alloc_array(&arena, 10, sizeof(int));
+    TEST_ASSERT(ok2 != NULL, "second valid array alloc should succeed");
+    TEST_ASSERT(ok2 != ok1, "array allocations should be distinct");
+
+    /* elem == 0 must not divide-by-zero; it is a benign zero-size request. */
+    void *zero_elem = ln_arena_alloc_array(&arena, SIZE_MAX, 0);
+    TEST_ASSERT(zero_elem != NULL, "zero element size should be a valid alloc");
+
+    ln_arena_destroy(&arena);
+    return 1;
+}
+
 /*============================================================================
  * Error Code Tests
  *============================================================================*/
@@ -881,6 +909,7 @@ int main(void)
     /* Macro tests */
     printf("Macro tests:\n");
     RUN_TEST(test_macros);
+    RUN_TEST(test_alloc_array_overflow);
     printf("\n");
 
     /* Usage pattern tests */

--- a/tests/turbo_test_result.c
+++ b/tests/turbo_test_result.c
@@ -821,6 +821,72 @@ static int test_mixed_field_types(void)
 }
 
 /*============================================================================
+ * JSON Estimate Robustness (control-char escaping must not undercount)
+ *============================================================================*/
+
+/*
+ * Regression for the serialization-estimate undercount (FINDING #3):
+ * a value/name/tag dominated by control bytes (0x01) escapes to "\uXXXX"
+ * (6 output bytes per input byte). The old estimate budgeted only ~2x, so
+ * ln_fast_to_json returned -1 and the line was SILENTLY DROPPED. With the
+ * 6x worst-case estimate the buffer is always large enough.
+ */
+static int test_json_estimate_control_chars(void)
+{
+    ln_arena_t arena;
+    ln_fast_result_t result;
+    char json[8192];
+    size_t out_len = 0;
+
+    ln_arena_init(&arena);
+    ln_fast_result_init(&result, &arena);
+
+    /* 47-byte all-0x01 inline value: true output ~= 47*6 + quotes ~= 284 B,
+     * which the old `len*2+2` estimate could not cover. */
+    char ctrl_val[47];
+    memset(ctrl_val, 0x01, sizeof(ctrl_val));
+    ln_fast_add_string_static(&result, "payload", 7, ctrl_val, sizeof(ctrl_val));
+
+    /* A field name full of control chars (also escaped via write_escaped). */
+    char ctrl_name[16];
+    memset(ctrl_name, 0x01, sizeof(ctrl_name) - 1);
+    ctrl_name[sizeof(ctrl_name) - 1] = '\0';
+    ln_fast_add_string_static(&result, ctrl_name, sizeof(ctrl_name) - 1, "v", 1);
+
+    /* A tag full of control chars (tags also go through write_escaped). */
+    char ctrl_tag[24];
+    memset(ctrl_tag, 0x01, sizeof(ctrl_tag) - 1);
+    ctrl_tag[sizeof(ctrl_tag) - 1] = '\0';
+    ln_fast_add_tag(&result, ctrl_tag);
+
+    /* The estimate must cover the true worst-case output. */
+    size_t est = ln_fast_json_estimate(&result);
+    TEST_ASSERT(est >= 282, "estimate must cover ~282B control-char value output");
+
+    /* Serialize must SUCCEED (no -1 / no silent drop) and fit our buffer. */
+    int r = ln_fast_to_json(&result, json, sizeof(json), &out_len);
+    TEST_ASSERT_EQ(r, 0, "control-char result must serialize without drop");
+    TEST_ASSERT(out_len > 0, "serialized length must be non-zero");
+    TEST_ASSERT(out_len <= est, "actual output must fit within the estimate");
+
+    /* Round-trip evidence: each 0x01 byte became a 6-byte unicode
+     * escape sequence in the serialized output. */
+    TEST_ASSERT(strstr(json, "\\u0001") != NULL,
+                "control byte must serialize as \\u0001 escape");
+
+    /* And the allocating path (which reuses the same estimate) must agree. */
+    char *jstr = NULL;
+    size_t jlen = 0;
+    int ra = ln_fast_to_json_alloc(&result, &jstr, &jlen);
+    TEST_ASSERT_EQ(ra, 0, "alloc path must serialize control-char result");
+    TEST_ASSERT(jstr != NULL && jlen > 0, "alloc path must yield output");
+    free(jstr);
+
+    ln_arena_destroy(&arena);
+    return 1;
+}
+
+/*============================================================================
  * Snapshot Tests
  *============================================================================*/
 
@@ -893,6 +959,70 @@ static int test_snapshot_survives_arena_reset(void)
         TEST_ASSERT(memcmp(sr->fields[0].v.str.ptr, "this-is-an-arena-allocated-value-that-is-long-enough-to-be-external", 66) == 0,
                     "rebased pointer should have correct data");
     }
+
+    ln_fast_result_snapshot_free(snap);
+    ln_arena_destroy(&arena);
+    return 1;
+}
+
+static int test_snapshot_self_contained_external_value(void)
+{
+    /* Regression: long (>= 48B) field VALUES are stored by
+     * ln_fast_add_string_static as non-owning pointers straight into the
+     * input line (LN_FFIELD_STATIC_VAL, type LN_FTYPE_STRING) — they are NOT
+     * in the arena, so the old snapshot copied the raw input-line pointer
+     * verbatim. After the input line is freed/overwritten that pointer
+     * dangles (use-after-free). The snapshot must copy such values into its
+     * own backing buffer.  Under ASan, the pre-fix code reads freed memory. */
+    ln_arena_t arena;
+    ln_fast_result_t result;
+
+    ln_arena_init(&arena);
+    ln_fast_result_init(&result, &arena);
+
+    /* Heap-allocated input line (so ASan tracks the free precisely). */
+    static const char payload[] =
+        "this-external-value-is-well-over-forty-eight-bytes-and-lives-in-the-input-line";
+    const size_t plen = sizeof(payload) - 1;   /* 78 bytes, >= 48 -> external */
+    char *input = malloc(plen + 1);
+    TEST_ASSERT(input != NULL, "input alloc");
+    memcpy(input, payload, plen + 1);
+
+    /* External string VALUE that points into the input buffer. */
+    ln_fast_add_string_static(&result, "long_field", 10, input, (uint32_t)plen);
+    TEST_ASSERT_EQ(result.fields[0].type, LN_FTYPE_STRING,
+                   "value should be external (>= 48B)");
+    TEST_ASSERT(result.fields[0].v.str.ptr == input,
+                "pre-snapshot pointer references the input line");
+
+    /* original also points into the input line. */
+    ln_fast_set_original(&result, input, (uint32_t)plen);
+
+    /* Snapshot — empty arena, value/original are NOT arena-backed. */
+    ln_fast_result_snapshot_t *snap = ln_fast_result_snapshot_create(&result, &arena);
+    TEST_ASSERT(snap != NULL, "snapshot should be created");
+
+    /* The snapshot value pointer must NOT alias the input line anymore. */
+    const ln_fast_result_t *sr = ln_fast_result_snapshot_get(snap);
+    TEST_ASSERT(sr->fields[0].v.str.ptr != input,
+                "snapshot value must not alias the input line");
+
+    /* Scribble + free the input line: any dangling pointer now reads garbage
+     * (or freed memory under ASan). */
+    memset(input, 'Z', plen);
+    free(input);
+
+    /* Snapshot must still return the original bytes. */
+    TEST_ASSERT_EQ(sr->fields[0].v.str.len, (uint32_t)plen, "value length preserved");
+    TEST_ASSERT(memcmp(sr->fields[0].v.str.ptr, payload, plen) == 0,
+                "snapshot value survives input-line free/overwrite");
+    TEST_ASSERT_EQ(sr->fields[0].v.str.ptr[plen], '\0',
+                "snapshot value is NUL-terminated");
+
+    /* original must also be self-contained. */
+    TEST_ASSERT(sr->original != NULL, "original preserved");
+    TEST_ASSERT(memcmp(sr->original, payload, plen) == 0,
+                "snapshot original survives input-line free/overwrite");
 
     ln_fast_result_snapshot_free(snap);
     ln_arena_destroy(&arena);
@@ -1024,10 +1154,16 @@ int main(void)
     RUN_TEST(test_mixed_field_types);
     printf("\n");
 
+    /* JSON estimate robustness tests */
+    printf("JSON estimate robustness tests:\n");
+    RUN_TEST(test_json_estimate_control_chars);
+    printf("\n");
+
     /* Snapshot tests */
     printf("Snapshot tests:\n");
     RUN_TEST(test_snapshot_create_basic);
     RUN_TEST(test_snapshot_survives_arena_reset);
+    RUN_TEST(test_snapshot_self_contained_external_value);
     RUN_TEST(test_snapshot_null_safety);
     RUN_TEST(test_snapshot_no_arena);
     printf("\n");

--- a/tests/turbo_test_simd.c
+++ b/tests/turbo_test_simd.c
@@ -197,6 +197,57 @@ static int test_find_not_char_set_edge(void)
     return 1;
 }
 
+/*
+ * Regression: embedded NUL must NOT truncate the SSE4.2 scan.
+ *
+ * The buggy implicit-length PCMPISTRI treated each 16-byte chunk as
+ * ending at its first 0x00, so a delimiter after an embedded NUL was
+ * silently skipped -> the SSE path mis-segmented lines that the NEON
+ * and scalar paths parsed correctly (detection evasion). With the
+ * explicit-length PCMPESTRI fix, all three backends must agree.
+ *
+ * The chunk below is exactly 16 bytes so it is consumed entirely by the
+ * SIMD fast path (i + 16 <= len), exercising the patched code rather
+ * than the scalar tail.
+ */
+static int test_embedded_nul_no_truncation(void)
+{
+    /* 16-byte chunk: "aaaa\0bbb;ccccccc" — NUL at idx 4, ';' at idx 8 */
+    static const char chunk[16] = {
+        'a','a','a','a','\0','b','b','b',
+        ';','c','c','c','c','c','c','c'
+    };
+
+    /* find_char_set must find ';' at offset 8, not skip the chunk */
+    TEST_ASSERT_EQ(ln_simd_find_char_set(chunk, 16, ";"), 8,
+                   "find ';' after embedded NUL (SSE fast path)");
+
+    /* find_not_char_set: first byte not in {a} is the NUL at offset 4 */
+    TEST_ASSERT_EQ(ln_simd_find_not_char_set(chunk, 16, "a"), 4,
+                   "first non-'a' is the embedded NUL at offset 4");
+
+    /* skip_space: leading whitespace then NUL then ';' — NUL stops skip */
+    static const char wschunk[16] = {
+        ' ',' ',' ','\0',' ',' ',' ',';',
+        'c','c','c','c','c','c','c','c'
+    };
+    TEST_ASSERT_EQ(ln_simd_skip_space(wschunk, 16), 3,
+                   "skip_space stops at embedded NUL (offset 3)");
+
+    /*
+     * Cross-check: results must match the byte-accurate scalar reference,
+     * regardless of which backend was compiled in.
+     */
+    {
+        size_t ref = 16, k;
+        for (k = 0; k < 16; k++) { if (chunk[k] == ';') { ref = k; break; } }
+        TEST_ASSERT_EQ(ln_simd_find_char_set(chunk, 16, ";"), ref,
+                       "find_char_set agrees with scalar reference");
+    }
+
+    return 1;
+}
+
 /*============================================================================
  * skip_space Tests
  *============================================================================*/
@@ -822,6 +873,7 @@ int main(void)
     printf("find_not_char_set tests:\n");
     RUN_TEST(test_find_not_char_set_basic);
     RUN_TEST(test_find_not_char_set_edge);
+    RUN_TEST(test_embedded_nul_no_truncation);
     printf("\n");
 
     printf("skip_space tests:\n");

--- a/tests/turbo_test_vm.c
+++ b/tests/turbo_test_vm.c
@@ -219,10 +219,15 @@ static int test_instruction_builders(void)
     TEST_ASSERT(strncmp(i.data.char_to.name, "msg", 3) == 0, "field name");
 
     /* FIELD_NAME_VALUE */
-    i = ln_i_field_name_value("pairs", ' ', '=');
+    i = ln_i_field_name_value("pairs", ' ', '=', 0);
     TEST_ASSERT_EQ(i.op, OP_FIELD_NAME_VALUE, "field_name_value opcode");
     TEST_ASSERT_EQ(i.data.char_to.delim, ' ', "separator");
     TEST_ASSERT_EQ(i.data.char_to.ass, '=', "assignator");
+    TEST_ASSERT_EQ(i.data.char_to.ignore_ws, 0, "ignore_ws default");
+
+    /* FIELD_NAME_VALUE with ignore_whitespaces */
+    i = ln_i_field_name_value("pairs", ',', ':', 1);
+    TEST_ASSERT_EQ(i.data.char_to.ignore_ws, 1, "ignore_ws set");
 
     /* SKIP_SPACE */
     i = ln_i_skip_space();

--- a/tests/turbo_test_vm.c
+++ b/tests/turbo_test_vm.c
@@ -795,6 +795,162 @@ static int test_vm_call_ret(void)
 }
 
 /*============================================================================
+ * Security Regression Tests (audit #4 #5 #6 #7)
+ *============================================================================*/
+
+/* #5/#4: a JUMP whose target lands outside [0, code_len) is rejected
+ * cleanly with LN_VM_ERROR rather than reading off the end of code. */
+static int test_vm_jump_out_of_range(void)
+{
+    ln_arena_t arena;
+    ln_vm_t vm;
+    ln_fast_result_t result;
+
+    setup_vm(&vm, &arena, &result);
+
+    ln_instr_t code[] = {
+        ln_i_jump(1000),    /* [0] target far past end of program */
+        ln_i_match("rule1"),/* [1] */
+    };
+    ln_program_t prog = ln_program_make(code, 2, "test_jump_oob");
+
+    int r = ln_vm_exec(&vm, &prog, "", 0, &result);
+    TEST_ASSERT_EQ(r, LN_VM_ERROR, "out-of-range jump must error");
+    TEST_ASSERT(vm.error != NULL, "error message set");
+
+    teardown_vm(&vm, &arena);
+    return 1;
+}
+
+/* #5: a negative JUMP offset that would wrap uint32 arithmetic is caught
+ * by the int64 range check (lands < 0 -> LN_VM_ERROR). */
+static int test_vm_jump_negative_wrap(void)
+{
+    ln_arena_t arena;
+    ln_vm_t vm;
+    ln_fast_result_t result;
+
+    setup_vm(&vm, &arena, &result);
+
+    ln_instr_t code[] = {
+        ln_i_jump(-100),    /* [0] target = -100, below 0 */
+        ln_i_match("rule1"),/* [1] */
+    };
+    ln_program_t prog = ln_program_make(code, 2, "test_jump_neg");
+
+    int r = ln_vm_exec(&vm, &prog, "", 0, &result);
+    TEST_ASSERT_EQ(r, LN_VM_ERROR, "negative jump target must error");
+
+    teardown_vm(&vm, &arena);
+    return 1;
+}
+
+/* #4: a program with no terminating HALT/MATCH (PC runs off the end via
+ * NOP fall-through) is caught by the DISPATCH bounds guard, not an OOB
+ * read + wild indirect jump. */
+static int test_vm_pc_runs_off_end(void)
+{
+    ln_arena_t arena;
+    ln_vm_t vm;
+    ln_fast_result_t result;
+
+    setup_vm(&vm, &arena, &result);
+
+    ln_instr_t code[] = {
+        ln_i_nop(),         /* [0] */
+        ln_i_nop(),         /* [1] -> pc advances to 2 == code_len */
+    };
+    ln_program_t prog = ln_program_make(code, 2, "test_runoff");
+
+    int r = ln_vm_exec(&vm, &prog, "x", 1, &result);
+    TEST_ASSERT_EQ(r, LN_VM_ERROR, "PC off-end must error, not crash");
+    TEST_ASSERT(vm.error != NULL, "error message set");
+
+    teardown_vm(&vm, &arena);
+    return 1;
+}
+
+/* #7: an always-succeeding self-loop (JUMP offset=0) must hit the
+ * instruction limit and return LN_VM_LIMIT instead of spinning forever. */
+static int test_vm_self_loop_instruction_limit(void)
+{
+    ln_arena_t arena;
+    ln_vm_t vm;
+    ln_fast_result_t result;
+
+    setup_vm(&vm, &arena, &result);
+
+    ln_instr_t code[] = {
+        ln_i_jump(0),       /* [0] jump to self forever */
+    };
+    ln_program_t prog = ln_program_make(code, 1, "test_self_loop");
+
+    int r = ln_vm_exec(&vm, &prog, "", 0, &result);
+    TEST_ASSERT_EQ(r, LN_VM_LIMIT, "self-loop must hit instruction limit");
+
+    teardown_vm(&vm, &arena);
+    return 1;
+}
+
+/* #6b: a LITERAL whose aux length exceeds the inline buffer must not
+ * over-read data.str. With no input it simply fails to match (NOMATCH),
+ * and crucially performs no out-of-bounds compare. */
+static int test_vm_literal_oversized_aux(void)
+{
+    ln_arena_t arena;
+    ln_vm_t vm;
+    ln_fast_result_t result;
+
+    setup_vm(&vm, &arena, &result);
+
+    ln_instr_t lit = ln_i_literal("hello", 5);
+    lit.aux = 60000; /* malformed: far beyond LN_INSTR_MAX_INLINE */
+    ln_instr_t code[] = {
+        lit,                 /* [0] */
+        ln_i_match("rule1"), /* [1] */
+    };
+    ln_program_t prog = ln_program_make(code, 2, "test_lit_oversized");
+
+    /* Provide a long input so the REMAINING() check alone would pass;
+     * the len<=inline guard is what must reject the over-read. */
+    static const char big[100] = {0};
+    int r = ln_vm_exec(&vm, &prog, big, sizeof(big), &result);
+    TEST_ASSERT_EQ(r, LN_VM_NOMATCH, "oversized literal must not match/over-read");
+
+    teardown_vm(&vm, &arena);
+    return 1;
+}
+
+/* #6a: an inline literal builder must clamp aux to the inline capacity so
+ * it can never describe more bytes than were actually stored. */
+static int test_inline_literal_len_clamped(void)
+{
+    char huge[200];
+    memset(huge, 'A', sizeof(huge));
+    ln_instr_t i = ln_i_literal(huge, 200);
+    TEST_ASSERT(i.aux <= LN_INSTR_MAX_INLINE, "literal aux clamped to inline size");
+    return 1;
+}
+
+/* #6a: name-based builders must leave a NUL terminator even for a
+ * maximally long name (no strlen over-read). */
+static int test_inline_name_nul_terminated(void)
+{
+    char huge[200];
+    memset(huge, 'B', sizeof(huge));
+    huge[sizeof(huge) - 1] = '\0';
+
+    ln_instr_t f = ln_i_field(OP_FIELD_WORD, huge);
+    TEST_ASSERT(f.data.str[LN_INSTR_MAX_INLINE - 1] == '\0',
+                "field name reserves NUL terminator");
+
+    ln_instr_t c = ln_i_field_char_to(huge, ',');
+    TEST_ASSERT(c.data.char_to.name[55] == '\0',
+                "char_to name reserves NUL terminator");
+    return 1;
+}
+
+/*============================================================================
  * Field Context Tests (".." substitution)
  *============================================================================*/
 
@@ -1051,6 +1207,16 @@ int main(void)
 
     printf("Call/ret tests:\n");
     RUN_TEST(test_vm_call_ret);
+    printf("\n");
+
+    printf("Security regression tests:\n");
+    RUN_TEST(test_vm_jump_out_of_range);
+    RUN_TEST(test_vm_jump_negative_wrap);
+    RUN_TEST(test_vm_pc_runs_off_end);
+    RUN_TEST(test_vm_self_loop_instruction_limit);
+    RUN_TEST(test_vm_literal_oversized_aux);
+    RUN_TEST(test_inline_literal_len_clamped);
+    RUN_TEST(test_inline_name_nul_terminated);
     printf("\n");
 
     printf("Field context tests:\n");

--- a/tests/turbo_test_vm.c
+++ b/tests/turbo_test_vm.c
@@ -72,8 +72,9 @@ static void setup_vm(ln_vm_t *vm, ln_arena_t *arena, ln_fast_result_t *result)
 }
 
 /** Common test teardown */
-static void teardown_vm(ln_arena_t *arena)
+static void teardown_vm(ln_vm_t *vm, ln_arena_t *arena)
 {
+    ln_vm_destroy(vm);
     ln_arena_destroy(arena);
 }
 
@@ -123,7 +124,7 @@ static int test_vm_init(void)
     TEST_ASSERT_EQ(vm.field_ctx_sp, 0, "field_ctx_sp should be 0");
     TEST_ASSERT(vm.matched_rule == NULL, "no match yet");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -162,7 +163,7 @@ static int test_vm_reset(void)
     /* Reset NULL should not crash */
     ln_vm_reset(NULL);
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -284,7 +285,7 @@ static int test_vm_halt(void)
     TEST_ASSERT_EQ(r, LN_VM_NOMATCH, "halt = no match");
     TEST_ASSERT(!ln_vm_matched(&vm), "not matched");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -309,7 +310,7 @@ static int test_vm_literal_match(void)
     TEST_ASSERT_EQ(ln_vm_consumed(&vm), 5, "consumed all input");
     TEST_ASSERT_EQ(ln_vm_remaining(&vm), 0, "no remaining");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -331,7 +332,7 @@ static int test_vm_literal_no_match(void)
     TEST_ASSERT_EQ(r, LN_VM_NOMATCH, "should not match");
     TEST_ASSERT(!ln_vm_matched(&vm), "not matched");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -357,7 +358,7 @@ static int test_vm_char_match(void)
     r = ln_vm_exec(&vm, &prog, "B", 1, &result);
     TEST_ASSERT_EQ(r, LN_VM_NOMATCH, "should not match");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -379,7 +380,7 @@ static int test_vm_nop(void)
     int r = ln_vm_exec(&vm, &prog, "", 0, &result);
     TEST_ASSERT_EQ(r, LN_VM_OK, "NOPs don't block");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -405,7 +406,7 @@ static int test_vm_jump(void)
     int r = ln_vm_exec(&vm, &prog, "", 0, &result);
     TEST_ASSERT_EQ(r, LN_VM_OK, "jump should skip halt");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -431,7 +432,7 @@ static int test_vm_fork_first_path(void)
     TEST_ASSERT_EQ(r, LN_VM_OK, "should match first path");
     TEST_ASSERT(strcmp(vm.matched_rule, "rule_hello") == 0, "first path rule");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -457,7 +458,7 @@ static int test_vm_fork_second_path(void)
     TEST_ASSERT(strcmp(vm.matched_rule, "rule_world") == 0, "second path rule");
     TEST_ASSERT(vm.backtrack_count > 0, "backtrack happened");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -481,7 +482,7 @@ static int test_vm_fork_neither(void)
     int r = ln_vm_exec(&vm, &prog, "xxxxx", 5, &result);
     TEST_ASSERT_EQ(r, LN_VM_NOMATCH, "neither path matches");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -506,7 +507,7 @@ static int test_vm_fail_opcode(void)
     TEST_ASSERT_EQ(r, LN_VM_OK, "should take alt path");
     TEST_ASSERT(strcmp(vm.matched_rule, "alt") == 0, "alt rule matched");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -533,7 +534,7 @@ static int test_vm_skip_space(void)
     int r = ln_vm_exec(&vm, &prog, "hello   world", 13, &result);
     TEST_ASSERT_EQ(r, LN_VM_OK, "skip space match");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -555,7 +556,7 @@ static int test_vm_skip_n(void)
     int r = ln_vm_exec(&vm, &prog, "123world", 8, &result);
     TEST_ASSERT_EQ(r, LN_VM_OK, "skip N match");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -589,7 +590,7 @@ static int test_vm_field_word(void)
     TEST_ASSERT_EQ(vlen, 6, "value length");
     TEST_ASSERT(memcmp(val, "myhost", 6) == 0, "value content");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -615,7 +616,7 @@ static int test_vm_field_int(void)
     TEST_ASSERT_EQ(f->type, LN_FTYPE_INT, "type is INT");
     TEST_ASSERT_EQ(f->v.i, -42, "value is -42");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -645,7 +646,7 @@ static int test_vm_field_rest(void)
     TEST_ASSERT_EQ(vlen, 15, "rest length");
     TEST_ASSERT(memcmp(val, "everything else", 15) == 0, "rest content");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -679,7 +680,7 @@ static int test_vm_field_char_to(void)
     val = field_str(fv, &vlen);
     TEST_ASSERT(memcmp(val, "myvalue", 7) == 0, "val value");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -707,7 +708,7 @@ static int test_vm_field_ipv4(void)
     TEST_ASSERT(val != NULL, "value not null");
     TEST_ASSERT(memcmp(val, "192.168.1.1", 11) == 0, "ipv4 value");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -731,7 +732,7 @@ static int test_vm_field_quoted(void)
     const ln_fast_field_t *f = find_field(&result, "msg");
     TEST_ASSERT(f != NULL, "field found");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -759,7 +760,7 @@ static int test_vm_tag(void)
     TEST_ASSERT(ln_fast_has_tag(&result, "syslog"), "tag 'syslog' present");
     TEST_ASSERT(!ln_fast_has_tag(&result, "other"), "tag 'other' absent");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -789,7 +790,7 @@ static int test_vm_call_ret(void)
     int r = ln_vm_exec(&vm, &prog, "hello world", 11, &result);
     TEST_ASSERT_EQ(r, LN_VM_OK, "call/ret should match");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -822,7 +823,7 @@ static int test_vm_field_context(void)
     const ln_fast_field_t *f = find_field(&result, "src_ip");
     TEST_ASSERT(f != NULL, "field 'src_ip' found (resolved from '..')");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 
@@ -991,7 +992,7 @@ static int test_vm_syslog_like(void)
     TEST_ASSERT(strcmp(result.rule_id, "syslog_rule") == 0, "rule id");
     TEST_ASSERT(result.flags & LN_FRESULT_MATCHED, "matched flag");
 
-    teardown_vm(&arena);
+    teardown_vm(&vm, &arena);
     return 1;
 }
 


### PR DESCRIPTION
The liblognorm side of the TurboVM patch set from rsyslog PR #6667, covering the two items flagged here.

  ## 1. Public Turbo header contract (supersedes #415)
  - Install a single curated, opaque header `lognorm-turbo.h`; stop installing the internal `turbo*.h`. Installed set is now `liblognorm.h`, `lognorm-features.h`, `lognorm-turbo.h`.
  - Opaque `ln_fast_result_t` / `ln_fast_result_snapshot_t`, the `LN_FTYPE_*` enum and `LN_FFIELD_NESTED`; function-level API only — no struct layout crosses the boundary.
  - New accessor `ln_fast_result_get_field_typed()` closes the last struct-peek in rsyslog's mmnormalize.
  - libtool `version-info 6:0:1 -> 7:0:2` (soname stays `.so.5`). `turbo*.h` stay built/distributed but uninstalled.
  - Folds in #415's version-info bump, `turbo.rst`/PDAG doc fix and ChangeLog, so **#415 can be dropped once this lands**.

  ## 2. name-value-list `ignore_whitespaces` in TurboVM (closes #414)
  - Implemented natively in both VM handlers with the same semantics as the recursive parser (leading/trailing trim per the standard rules; quoted values verbatim; pair-transition matching). Forward whitespace
  skips use the existing SIMD `ln_simd_skip_space`.
  - Gated per-instruction, so the option-off hot path is byte-for-byte unchanged.
  - Adds `tests/field_name_value_whitespace_turbo.sh` asserting TurboVM output matches the standard parser.

  ## Validation
  `make distcheck` (`--enable-turbo`) passes; clean `--enable-turbo`/`--disable-turbo` builds; `-Werror=redundant-decls` clean; codestyle (`-l 120`) clean; install ships exactly the three headers; suite 135/135.

  Closes #414.
