### PR TITLE
Add binary unparsed-data field for control bytes

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 ----------------------------------------------------------------------
 Version 2.1.0, 2026-06-25
+- add unparsed-data-binary for failed parses containing ASCII control bytes;
+  the field contains the complete unparsed byte span as lowercase hexadecimal
+  and can be disabled with LN_CTXOPT_NO_UNPARSED_DATA_BINARY.
 - add TurboVM bytecode engine for high-performance log parsing
   Compiles rulebases into optimized bytecode executed by a linear VM
   with SIMD-accelerated parsing primitives (SSE4.2 on x86-64, NEON

--- a/src/internal.h
+++ b/src/internal.h
@@ -121,6 +121,9 @@ const char * ln_DataForDisplayCharTo(__attribute__((unused)) ln_ctx ctx, void *c
 const char * ln_DataForDisplayLiteral(__attribute__((unused)) ln_ctx ctx, void *const pdata);
 const char * ln_JsonConfLiteral(__attribute__((unused)) ln_ctx ctx, void *const pdata);
 
+int ln_addUnparsedDataBinaryField(ln_ctx ctx, const char *str, size_t strLen,
+		struct json_object *json);
+
 /* here we add some stuff from the compatibility layer */
 #ifndef HAVE_STRNDUP
 char * strndup(const char *s, size_t n);

--- a/src/liblognorm.c
+++ b/src/liblognorm.c
@@ -25,6 +25,7 @@
  * A copy of the LGPL v2.1 can be found in the file "COPYING" in this distribution.
  */
 #include "config.h"
+#include <limits.h>
 #include <string.h>
 #include <errno.h>
 
@@ -34,6 +35,7 @@
 #include "samp.h"
 #include "v1_liblognorm.h"
 #include "v1_ptree.h"
+#include "internal.h"
 #ifdef ENABLE_TURBO
 #include "turbo.h"
 #endif
@@ -118,6 +120,47 @@ unsigned
 ln_getCtxOpts(ln_ctx ctx)
 {
 	return ctx->opts;
+}
+
+
+int
+ln_addUnparsedDataBinaryField(ln_ctx ctx, const char *str, const size_t strLen,
+		struct json_object *json)
+{
+	static const char hex[] = "0123456789abcdef";
+	struct json_object *value;
+	char *encoded;
+	size_t i;
+
+	if(ctx->opts & LN_CTXOPT_NO_UNPARSED_DATA_BINARY)
+		return 0;
+
+	for(i = 0 ; i < strLen ; ++i) {
+		const unsigned char c = (unsigned char) str[i];
+		if(c < 0x20 || c == 0x7f)
+			break;
+	}
+	if(i == strLen)
+		return 0;
+
+	if(strLen > (size_t) INT_MAX / 2)
+		return LN_OVER_SIZE_LIMIT;
+	if((encoded = malloc(strLen * 2 + 1)) == NULL)
+		return LN_NOMEM;
+
+	for(i = 0 ; i < strLen ; ++i) {
+		const unsigned char c = (unsigned char) str[i];
+		encoded[i * 2] = hex[c >> 4];
+		encoded[i * 2 + 1] = hex[c & 0x0f];
+	}
+	encoded[strLen * 2] = '\0';
+	value = json_object_new_string_len(encoded, strLen * 2);
+	free(encoded);
+	if(value == NULL)
+		return LN_NOMEM;
+	json_object_object_add(json, "unparsed-data-binary", value);
+
+	return 0;
 }
 
 

--- a/src/liblognorm.h
+++ b/src/liblognorm.h
@@ -146,6 +146,7 @@ int ln_exitCtx(ln_ctx ctx);
 #define LN_CTXOPT_ADD_RULE		0x08 /**< add mockup rule */
 #define LN_CTXOPT_ADD_RULE_LOCATION	0x10 /**< add rule location (file, lineno) to metadata */
 #define LN_CTXOPT_TURBO			0x20 /**< enable TurboVM parsing */
+#define LN_CTXOPT_NO_UNPARSED_DATA_BINARY 0x40 /**< do not add hexadecimal unparsed data for control bytes */
 /**
  * Set options on ctx.
  *

--- a/src/pdag.c
+++ b/src/pdag.c
@@ -1314,7 +1314,8 @@ addRuleMetadata(npb_t *const __restrict__ npb,
  * add unparsed string to event.
  */
 static inline int
-addUnparsedField(const char *str, const size_t strLen, const size_t offs, struct json_object *json)
+addUnparsedField(ln_ctx ctx, const char *str, const size_t strLen, const size_t offs,
+		struct json_object *json)
 {
 	int r = 1;
 	struct json_object *value;
@@ -1326,6 +1327,7 @@ addUnparsedField(const char *str, const size_t strLen, const size_t offs, struct
 		goto done;
 	}
 	json_object_object_add(json, UNPARSED_DATA_KEY, value);
+	CHKR(ln_addUnparsedDataBinaryField(ctx, str + offs, strLen - offs, json));
 
 	r = 0;
 done:
@@ -1811,7 +1813,7 @@ ln_normalize(ln_ctx ctx, const char *str, const size_t strLen, struct json_objec
 		addRuleMetadata(&npb, *json_p, endNode);
 		r = 0;
 	} else {
-		addUnparsedField(str, strLen, npb.longestParsedTo, *json_p);
+		addUnparsedField(ctx, str, strLen, npb.longestParsedTo, *json_p);
 	}
 
 	if(ctx->opts & LN_CTXOPT_ADD_RULE) {

--- a/src/v1_ptree.c
+++ b/src/v1_ptree.c
@@ -530,7 +530,7 @@ ln_genDotPTreeGraph(struct ln_ptree *tree, es_str_t **str)
  * add unparsed string to event.
  */
 static int
-addUnparsedField(const char *str, size_t strLen, int offs, struct json_object *json)
+addUnparsedField(ln_ctx ctx, const char *str, size_t strLen, int offs, struct json_object *json)
 {
 	int r = 1;
 	struct json_object *value;
@@ -547,6 +547,7 @@ addUnparsedField(const char *str, size_t strLen, int offs, struct json_object *j
 		goto done;
 	}
 	json_object_object_add(json, UNPARSED_DATA_KEY, value);
+	CHKR(ln_addUnparsedDataBinaryField(ctx, str + offs, strLen - offs, json));
 
 	r = 0;
 done:
@@ -876,9 +877,9 @@ ln_v1_normalize(ln_ctx ctx, const char *str, size_t strLen, struct json_object *
 	if(left != 0 || !endNode->flags.isTerminal) {
 		/* we could not successfully parse, some unparsed items left */
 		if(left < 0) {
-			addUnparsedField(str, strLen, strLen, *json_p);
+			addUnparsedField(ctx, str, strLen, strLen, *json_p);
 		} else {
-			addUnparsedField(str, strLen, strLen - left, *json_p);
+			addUnparsedField(ctx, str, strLen, strLen - left, *json_p);
 		}
 	} else {
 		/* success, finalize event */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,4 +1,4 @@
-check_PROGRAMS = json_eq err_callback_cookie
+check_PROGRAMS = json_eq err_callback_cookie unparsed_data_binary
 TESTS_TURBO_SHELLS = \
 	turbo_smoke.sh \
 	field_name_value_whitespace_turbo.sh \
@@ -15,6 +15,11 @@ err_callback_cookie_SOURCES = err_callback_cookie.c
 err_callback_cookie_CPPFLAGS = $(JSON_C_CFLAGS) $(WARN_CFLAGS) -I$(top_srcdir)/src
 err_callback_cookie_LDADD = $(LIBLOGNORM_LIBS)
 err_callback_cookie_LDFLAGS = -no-install
+
+unparsed_data_binary_SOURCES = unparsed_data_binary.c
+unparsed_data_binary_CPPFLAGS = $(JSON_C_CFLAGS) $(WARN_CFLAGS) -I$(top_srcdir)/src
+unparsed_data_binary_LDADD = $(LIBLOGNORM_LIBS) $(JSON_C_LIBS)
+unparsed_data_binary_LDFLAGS = -no-install
 
 #user_test_SOURCES = user_test.c
 #user_test_CPPFLAGS = $(LIBLOGNORM_CFLAGS) $(JSON_C_CFLAGS) $(LIBESTR_CFLAGS)
@@ -172,7 +177,8 @@ TESTS_SHELLSCRIPTS += \
 #re-add to TESTS if needed: user_test
 TESTS = \
         $(TESTS_SHELLSCRIPTS) \
-        err_callback_cookie.sh
+        err_callback_cookie.sh \
+        unparsed_data_binary.sh
 
 REGEXP_TESTS = \
 	field_regex_default_group_parse_and_return.sh \
@@ -188,6 +194,8 @@ EXTRA_DIST = exec.sh \
 	$(TESTS_TURBO_SHELLS) \
 	$(REGEXP_TESTS) \
 	err_callback_cookie.sh \
+	unparsed_data_binary.c \
+	unparsed_data_binary.sh \
 	$(json_eq_self_sources) \
 	$(user_test_SOURCES)
 

--- a/tests/unparsed_data_binary.c
+++ b/tests/unparsed_data_binary.c
@@ -66,29 +66,26 @@ main(void)
 		"rule=:prefix%value:number%\n";
 	static const char v1_rulebase[] =
 		"rule=:prefix%value:number%\n";
-	static const char control_message[] =
-		{'p', 'r', 'e', 'f', 'i', 'x', '\x01', 't', 'a', 'i', 'l'};
-	static const char printable_message[] =
-		{'p', 'r', 'e', 'f', 'i', 'x', ' ', 't', 'a', 'i', 'l'};
-	static const char utf8_message[] =
-		{'p', 'r', 'e', 'f', 'i', 'x', ' ', '\xc3', '\xa4'};
+	static const char control_message[] = "prefix\x01tail";
+	static const char printable_message[] = "prefix tail";
+	static const char utf8_message[] = "prefix \xc3\xa4";
 	int ret = 1;
 
-	if(run_case(v2_rulebase, 0, control_message, sizeof(control_message),
-			control_message + 6, sizeof(control_message) - 6, "017461696c", 10) != 0)
+	if(run_case(v2_rulebase, 0, control_message, sizeof(control_message) - 1,
+			control_message + 6, sizeof(control_message) - 7, "017461696c", 10) != 0)
 		goto done;
-	if(run_case(v1_rulebase, 0, control_message, sizeof(control_message),
-			control_message + 6, sizeof(control_message) - 6, "017461696c", 10) != 0)
+	if(run_case(v1_rulebase, 0, control_message, sizeof(control_message) - 1,
+			control_message + 6, sizeof(control_message) - 7, "017461696c", 10) != 0)
 		goto done;
-	if(run_case(v2_rulebase, 0, printable_message, sizeof(printable_message),
-			printable_message + 6, sizeof(printable_message) - 6, NULL, 0) != 0)
+	if(run_case(v2_rulebase, 0, printable_message, sizeof(printable_message) - 1,
+			printable_message + 6, sizeof(printable_message) - 7, NULL, 0) != 0)
 		goto done;
-	if(run_case(v2_rulebase, 0, utf8_message, sizeof(utf8_message),
-			utf8_message + 6, sizeof(utf8_message) - 6, NULL, 0) != 0)
+	if(run_case(v2_rulebase, 0, utf8_message, sizeof(utf8_message) - 1,
+			utf8_message + 6, sizeof(utf8_message) - 7, NULL, 0) != 0)
 		goto done;
 	if(run_case(v2_rulebase, LN_CTXOPT_NO_UNPARSED_DATA_BINARY, control_message,
-			sizeof(control_message), control_message + 6,
-			sizeof(control_message) - 6, NULL, 0) != 0)
+			sizeof(control_message) - 1, control_message + 6,
+			sizeof(control_message) - 7, NULL, 0) != 0)
 		goto done;
 
 	ret = 0;

--- a/tests/unparsed_data_binary.c
+++ b/tests/unparsed_data_binary.c
@@ -1,0 +1,97 @@
+#include "config.h"
+#include <string.h>
+
+#include "liblognorm.h"
+
+static int
+has_string_field(struct json_object *json, const char *name, const char *expected,
+		const size_t expected_len)
+{
+	struct json_object *value;
+
+	if(!json_object_object_get_ex(json, name, &value))
+		return 0;
+	if(json_object_get_type(value) != json_type_string)
+		return 0;
+	if((size_t) json_object_get_string_len(value) != expected_len)
+		return 0;
+	return memcmp(json_object_get_string(value), expected, expected_len) == 0;
+}
+
+static int
+run_case(const char *rulebase, const unsigned opts, const char *message,
+		const size_t message_len, const char *expected_unparsed,
+		const size_t expected_unparsed_len, const char *expected_binary,
+		const size_t expected_binary_len)
+{
+	ln_ctx ctx = NULL;
+	struct json_object *json = NULL;
+	int ret = 1;
+
+	if((ctx = ln_initCtx()) == NULL)
+		goto done;
+	if(opts != 0)
+		ln_setCtxOpts(ctx, opts);
+	if(ln_loadSamplesFromString(ctx, rulebase) != 0)
+		goto done;
+	ln_normalize(ctx, message, message_len, &json);
+	if(json == NULL)
+		goto done;
+	if(!has_string_field(json, "unparsed-data", expected_unparsed,
+			expected_unparsed_len))
+		goto done;
+	if(expected_binary == NULL) {
+		struct json_object *value;
+		if(json_object_object_get_ex(json, "unparsed-data-binary", &value))
+			goto done;
+	} else if(!has_string_field(json, "unparsed-data-binary", expected_binary,
+			expected_binary_len)) {
+		goto done;
+	}
+
+	ret = 0;
+done:
+	if(json != NULL)
+		json_object_put(json);
+	if(ctx != NULL)
+		ln_exitCtx(ctx);
+	return ret;
+}
+
+int
+main(void)
+{
+	static const char v2_rulebase[] =
+		"version=2\n"
+		"rule=:prefix%value:number%\n";
+	static const char v1_rulebase[] =
+		"rule=:prefix%value:number%\n";
+	static const char control_message[] =
+		{'p', 'r', 'e', 'f', 'i', 'x', '\x01', 't', 'a', 'i', 'l'};
+	static const char printable_message[] =
+		{'p', 'r', 'e', 'f', 'i', 'x', ' ', 't', 'a', 'i', 'l'};
+	static const char utf8_message[] =
+		{'p', 'r', 'e', 'f', 'i', 'x', ' ', '\xc3', '\xa4'};
+	int ret = 1;
+
+	if(run_case(v2_rulebase, 0, control_message, sizeof(control_message),
+			control_message + 6, sizeof(control_message) - 6, "017461696c", 10) != 0)
+		goto done;
+	if(run_case(v1_rulebase, 0, control_message, sizeof(control_message),
+			control_message + 6, sizeof(control_message) - 6, "017461696c", 10) != 0)
+		goto done;
+	if(run_case(v2_rulebase, 0, printable_message, sizeof(printable_message),
+			printable_message + 6, sizeof(printable_message) - 6, NULL, 0) != 0)
+		goto done;
+	if(run_case(v2_rulebase, 0, utf8_message, sizeof(utf8_message),
+			utf8_message + 6, sizeof(utf8_message) - 6, NULL, 0) != 0)
+		goto done;
+	if(run_case(v2_rulebase, LN_CTXOPT_NO_UNPARSED_DATA_BINARY, control_message,
+			sizeof(control_message), control_message + 6,
+			sizeof(control_message) - 6, NULL, 0) != 0)
+		goto done;
+
+	ret = 0;
+done:
+	return ret;
+}

--- a/tests/unparsed_data_binary.sh
+++ b/tests/unparsed_data_binary.sh
@@ -5,7 +5,11 @@ if [ -x "./unparsed_data_binary" ] && [ -d "../src/.libs" ]; then
 	test_bin="./unparsed_data_binary"
 	build_libdir="../src/.libs"
 else
-	script_dir="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+	script_dir="$(
+		CDPATH=
+		cd -- "$(dirname "$0")" || exit 1
+		pwd
+	)"
 	top_builddir="${top_builddir:-${script_dir}/..}"
 	test_bin="${top_builddir}/tests/unparsed_data_binary"
 	build_libdir="${top_builddir}/src/.libs"

--- a/tests/unparsed_data_binary.sh
+++ b/tests/unparsed_data_binary.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Verify binary unparsed-data output through the public API.
+
+if [ -x "./unparsed_data_binary" ] && [ -d "../src/.libs" ]; then
+	test_bin="./unparsed_data_binary"
+	build_libdir="../src/.libs"
+else
+	script_dir="$(CDPATH= cd -- "$(dirname "$0")" && pwd)"
+	top_builddir="${top_builddir:-${script_dir}/..}"
+	test_bin="${top_builddir}/tests/unparsed_data_binary"
+	build_libdir="${top_builddir}/src/.libs"
+fi
+
+if [ -n "${LD_LIBRARY_PATH}" ]; then
+	export LD_LIBRARY_PATH="${build_libdir}:${LD_LIBRARY_PATH}"
+else
+	export LD_LIBRARY_PATH="${build_libdir}"
+fi
+
+exec "${test_bin}"


### PR DESCRIPTION
## Summary

- add `unparsed-data-binary` for failed parses whose unparsed suffix includes an ASCII control byte
- encode the complete unparsed suffix as lowercase hexadecimal while retaining the existing textual `unparsed-data`
- add `LN_CTXOPT_NO_UNPARSED_DATA_BINARY` for callers that need to suppress the default behavior

## Why

Text JSON cannot safely preserve control bytes in failed normalization output. The companion field retains a lossless, machine-readable representation without changing existing output fields.

## Validation

- `make -j60 check` (129 passed)
- direct public API coverage for v1 and v2, printable and UTF-8-only suffixes, and the opt-out flag
